### PR TITLE
Offline draft simulator (simulate_draft)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,12 +187,13 @@ The NFL MCP Server provides **60+ MCP tools** organized into these categories:
 - **Start/Sit Recommendations**: `get_start_sit_recommendation`, `get_roster_recommendations`, `compare_players_for_slot`, `analyze_full_lineup`
 - **Vegas Lines**: `get_vegas_lines`, `get_game_environment`, `analyze_roster_vegas`, `get_stack_opportunities`
 
-#### 💰 Player Values & Draft Assistant (4 tools)
+#### 💰 Player Values & Draft Assistant (5 tools)
 Real market-consensus values (FantasyCalc, no API key) power trades and drafting:
 - `get_player_values` - Consensus market values (format-aware: PPR, superflex, teams, dynasty)
 - `get_player_value` - Single-player value by Sleeper id or name
 - `get_draft_board` - Tiered board ranked by **VBD** (value over positional replacement)
 - `recommend_draft_pick` - Live Sleeper-draft pick recommendations with roster-need weighting, value-cliff and positional-run detection
+- `simulate_draft` - **Offline snake-draft rehearsal** (solo, repeatable): opponents pick by need-weighted VBD with ADP noise, your slot picks optimally; returns your roster, a value-based standing, and aggregate structure over many runs
 
 The trade analyzer (`analyze_trade`) is built on the same real values, so it no longer
 treats every player as equal — it derives the league's format from Sleeper settings and
@@ -209,6 +210,18 @@ pick = await client.call_tool("recommend_draft_pick", {
     "my_slot": 3                            # your draft position
 })
 print(pick.data["top_pick"], pick.data["value_cliffs"])
+
+# Rehearse the whole draft offline before draft day (no mates needed):
+sim = await client.call_tool("simulate_draft", {
+    "my_slot": 3, "num_teams": 12, "scoring": "ppr", "seed": 42
+})
+print(sim.data["sample"]["my_team"], sim.data["sample"]["grade"])
+
+# Compare slots / structures over many runs:
+agg = await client.call_tool("simulate_draft", {
+    "my_slot": 3, "num_teams": 12, "num_sims": 100
+})
+print(agg.data["aggregate"])  # avg roster structure + grade distribution
 ```
 
 #### ❤️ Health Endpoint (REST)

--- a/nfl_mcp/draft_tools.py
+++ b/nfl_mcp/draft_tools.py
@@ -11,11 +11,17 @@ edge:
   draft state (who's already gone), models your roster construction and starter
   needs, detects positional runs and value cliffs, and tells you the best picks
   right now with reasoning.
+- simulate_draft: an OFFLINE snake-draft simulator to rehearse solo and
+  repeatedly. Opponents pick by need-weighted VBD with realistic ADP noise;
+  your slot picks optimally (same logic as recommend_draft_pick). Returns your
+  resulting roster, a value-based standing among all teams, and (for multiple
+  runs) aggregate roster structure.
 """
 
 from __future__ import annotations
 
 import logging
+import random
 from typing import Any, Dict, List, Optional, Tuple
 
 from .player_values import get_values_service, scoring_to_ppr
@@ -204,19 +210,24 @@ def _starter_requirements(settings: Dict) -> Dict[str, int]:
 
 
 def _need_multiplier(pos: str, my_counts: Dict[str, int], reqs: Dict[str, int], flex_filled: int) -> Tuple[float, str]:
-    """Weight a position by how badly the roster still needs it."""
+    """Weight a position by how badly the roster still needs it.
+
+    Multipliers are deliberately decisive so roster construction actually holds:
+    an unfilled starter slot should usually win over slightly-higher raw value at
+    an already-filled position.
+    """
     pos = pos.upper()
     if pos not in VBD_POSITIONS:
         return 1.0, "neutral"
     have = my_counts.get(pos, 0)
     need = reqs.get(pos, 0)
     if have < need:
-        return 1.20, "need_starter"
+        return 2.0, "need_starter"
     # Flex-eligible positions with an open flex slot
     if pos in ("RB", "WR", "TE") and flex_filled < reqs.get("FLEX", 0):
-        return 1.08, "fills_flex"
+        return 1.25, "fills_flex"
     if have >= need + 2:
-        return 0.85, "overfilled"
+        return 0.5, "overfilled"
     return 1.0, "depth"
 
 
@@ -410,3 +421,268 @@ async def recommend_draft_pick(
             + (" ⚠️ STALE values" if data.get("stale") else "")
         ),
     })
+
+
+# ==========================================================================
+# simulate_draft (offline rehearsal)
+# ==========================================================================
+
+def _flex_filled(counts: Dict[str, int], reqs: Dict[str, int]) -> int:
+    """RB/WR/TE drafted beyond their base starter requirements (fill FLEX)."""
+    return sum(max(0, counts.get(pos, 0) - reqs.get(pos, 0)) for pos in ("RB", "WR", "TE"))
+
+
+# Reasonable bench depth per position (on top of starter requirements) so a
+# simulated roster stops stacking one position and looks like a real draft.
+POS_BENCH_ALLOW = {"QB": 1, "TE": 2, "RB": 5, "WR": 5}
+
+
+def _position_caps(reqs: Dict[str, int]) -> Dict[str, int]:
+    return {pos: reqs.get(pos, 0) + POS_BENCH_ALLOW.get(pos, 4) for pos in VBD_POSITIONS}
+
+
+def _eligible_players(
+    avail: List[Dict], counts: Dict[str, int], reqs: Dict[str, int],
+    caps: Dict[str, int], picks_left: int,
+) -> List[Dict]:
+    """Restrict candidates so rosters fill starters and don't over-stack.
+
+    - Late-round guarantee: when there are just enough picks left to fill the
+      remaining required starter slots, only positions that fill one are allowed.
+    - Otherwise: drop positions already at their bench cap.
+    """
+    unfilled = {pos: max(0, reqs.get(pos, 0) - counts.get(pos, 0)) for pos in VBD_POSITIONS}
+    unfilled = {pos: u for pos, u in unfilled.items() if u > 0}
+    flex_need = max(0, reqs.get("FLEX", 0) - _flex_filled(counts, reqs))
+    total_unfilled = sum(unfilled.values()) + flex_need
+
+    if picks_left <= total_unfilled:
+        allowed = set(unfilled.keys())
+        if flex_need > 0:
+            allowed |= {"RB", "WR", "TE"}
+        forced = [p for p in avail if (p.get("position") or "").upper() in allowed]
+        if forced:
+            return forced
+
+    under_cap = [
+        p for p in avail
+        if counts.get((p.get("position") or "").upper(), 0) < caps.get((p.get("position") or "").upper(), 99)
+    ]
+    return under_cap or avail
+
+
+def _need_weighted_ranking(
+    available: List[Dict], counts: Dict[str, int], reqs: Dict[str, int]
+) -> List[Tuple[Dict, float]]:
+    """Rank available players by need-weighted VBD (best first) for one roster."""
+    flex = _flex_filled(counts, reqs)
+    scored: List[Tuple[Dict, float]] = []
+    for p in available:
+        pos = (p.get("position") or "").upper()
+        vbd = p.get("vbd")
+        if vbd is None:
+            vbd = (p.get("value") or 0) * 0.001  # keep real-VBD players ahead
+        mult, _ = _need_multiplier(pos, counts, reqs, flex)
+        scored.append((p, vbd * mult))
+    scored.sort(key=lambda x: x[1], reverse=True)
+    return scored
+
+
+def _snake_slot(overall_index: int, num_teams: int) -> int:
+    """Return the 1-based slot picking at a 0-based overall pick index (snake)."""
+    rnd = overall_index // num_teams
+    pos_in_round = overall_index % num_teams
+    if rnd % 2 == 0:
+        return pos_in_round + 1
+    return num_teams - pos_in_round
+
+
+def _grade_from_rank(rank: int, num_teams: int) -> str:
+    """Letter grade from a team's value-rank (1 = best) among the league."""
+    if num_teams <= 1:
+        return "A"
+    pct = (num_teams - rank) / (num_teams - 1)  # 1.0 best .. 0.0 worst
+    if pct >= 0.85:
+        return "A"
+    if pct >= 0.65:
+        return "B"
+    if pct >= 0.40:
+        return "C"
+    if pct >= 0.20:
+        return "D"
+    return "F"
+
+
+def _simulate_one(
+    pool: List[Dict], num_teams: int, rounds: int, my_slot: int,
+    reqs: Dict[str, int], randomness: float, rng: random.Random,
+) -> Dict[str, Any]:
+    """Run one full snake draft. Returns per-slot rosters and my team's detail."""
+    available = list(pool)  # already VBD-sorted; shallow copy of dict refs
+    by_id = {str(p["player_id"]): p for p in available}
+    drafted_ids: set = set()
+    counts: Dict[int, Dict[str, int]] = {s: {} for s in range(1, num_teams + 1)}
+    rosters: Dict[int, List[Dict]] = {s: [] for s in range(1, num_teams + 1)}
+    sigma = max(0.01, randomness * 5.0)
+    caps = _position_caps(reqs)
+
+    total_picks = num_teams * rounds
+    for overall in range(total_picks):
+        slot = _snake_slot(overall, num_teams)
+        rnd = overall // num_teams + 1
+        avail = [p for p in available if str(p["player_id"]) not in drafted_ids]
+        if not avail:
+            break
+        picks_left = rounds - len(rosters[slot])  # includes the current pick
+        avail = _eligible_players(avail, counts[slot], reqs, caps, picks_left)
+        scored = _need_weighted_ranking(avail, counts[slot], reqs)
+        if slot == my_slot:
+            choice = scored[0][0]  # optimal (same logic as recommend_draft_pick)
+        else:
+            idx = min(int(abs(rng.gauss(0, sigma))), len(scored) - 1)
+            choice = scored[idx][0]
+        pid = str(choice["player_id"])
+        drafted_ids.add(pid)
+        pos = (choice.get("position") or "").upper()
+        counts[slot][pos] = counts[slot].get(pos, 0) + 1
+        rosters[slot].append({
+            "round": rnd,
+            "pick_no": overall + 1,
+            "player_id": pid,
+            "name": choice.get("name"),
+            "position": pos,
+            "team": choice.get("team"),
+            "value": choice.get("value"),
+            "vbd": choice.get("vbd"),
+        })
+
+    # Team value totals (sum of VBD) -> standings
+    team_vbd = {s: round(sum((r.get("vbd") or 0) for r in rosters[s]), 1) for s in rosters}
+    standings = sorted(team_vbd.items(), key=lambda x: x[1], reverse=True)
+    my_rank = [i + 1 for i, (s, _) in enumerate(standings) if s == my_slot][0]
+
+    starters_filled = all(counts[my_slot].get(pos, 0) >= need for pos, need in reqs.items() if pos != "FLEX")
+    my_total_vbd = team_vbd[my_slot]
+
+    return {
+        "my_team": rosters[my_slot],
+        "my_position_counts": counts[my_slot],
+        "my_total_vbd": my_total_vbd,
+        "my_total_value": round(sum((r.get("value") or 0) for r in rosters[my_slot]), 0),
+        "starters_filled": starters_filled,
+        "my_value_rank": my_rank,
+        "grade": _grade_from_rank(my_rank, num_teams),
+        "standings": [{"slot": s, "total_vbd": v, "is_me": s == my_slot} for s, v in standings],
+        "rosters_by_slot": {
+            s: [f"{r['name']} ({r['position']})" for r in rosters[s]] for s in rosters
+        },
+    }
+
+
+@handle_http_errors(
+    default_data={"sample": None},
+    operation_name="simulating draft",
+)
+async def simulate_draft(
+    my_slot: int,
+    num_teams: int = 12,
+    rounds: int = 15,
+    scoring: str = "ppr",
+    superflex: bool = False,
+    dynasty: bool = False,
+    randomness: float = 0.15,
+    num_sims: int = 1,
+    seed: Optional[int] = None,
+    db=None,
+) -> Dict[str, Any]:
+    """Rehearse a full snake draft offline (solo, repeatable).
+
+    Opponents pick by need-weighted VBD with realistic ADP noise; your slot
+    picks optimally (same logic as recommend_draft_pick). Note: only QB/RB/WR/TE
+    are modeled (no K/DST in the consensus value set).
+
+    Args:
+        my_slot: Your draft position (1..num_teams).
+        num_teams: League size (default 12).
+        rounds: Number of rounds (default 15).
+        scoring: "ppr", "half-ppr", "standard".
+        superflex: True for 2-QB / superflex.
+        dynasty: Dynasty values vs redraft.
+        randomness: Opponent ADP noise 0..1 (0 = always best available).
+        num_sims: How many drafts to run. >1 returns aggregate structure.
+        seed: Optional RNG seed for reproducibility.
+
+    Returns: {sample: {my_team, standings, grade, ...}, aggregate?, format, source}
+    """
+    if my_slot < 1 or my_slot > num_teams:
+        return create_error_response(
+            f"my_slot must be between 1 and num_teams ({num_teams})",
+            ErrorType.VALIDATION, {"sample": None},
+        )
+
+    service = get_values_service(db)
+    data = await service.get_values(scoring_to_ppr(scoring), 2 if superflex else 1, num_teams, dynasty)
+    values = data.get("list", [])
+    if not values:
+        return create_error_response(
+            "No player values available (value API unreachable and no cache)",
+            ErrorType.HTTP, {"sample": None, "source": data.get("source")},
+        )
+
+    vbd = compute_vbd(values, num_teams, superflex)
+    pool = vbd["players"]
+
+    settings = {"slots_qb": 1, "slots_rb": 2, "slots_wr": 2, "slots_te": 1,
+                "slots_flex": 1, "slots_super_flex": 1 if superflex else 0}
+    reqs = _starter_requirements(settings)
+
+    n = max(1, min(int(num_sims), 200))
+    randomness = max(0.0, min(float(randomness), 1.0))
+
+    sims: List[Dict[str, Any]] = []
+    for i in range(n):
+        rng = random.Random((seed + i) if seed is not None else None)
+        sims.append(_simulate_one(pool, num_teams, rounds, my_slot, reqs, randomness, rng))
+
+    sample = sims[0]
+
+    result: Dict[str, Any] = {
+        "sample": sample,
+        "format": {"scoring": scoring, "superflex": superflex, "num_teams": num_teams,
+                   "dynasty": dynasty, "rounds": rounds},
+        "starter_requirements": reqs,
+        "num_sims": n,
+        "source": data.get("source"),
+        "stale": data.get("stale", False),
+    }
+
+    if n > 1:
+        # Aggregate my roster structure across sims.
+        pos_totals: Dict[str, float] = {}
+        vbd_sum = 0.0
+        rank_sum = 0.0
+        grade_counts: Dict[str, int] = {}
+        for s in sims:
+            for pos, c in s["my_position_counts"].items():
+                pos_totals[pos] = pos_totals.get(pos, 0) + c
+            vbd_sum += s["my_total_vbd"]
+            rank_sum += s["my_value_rank"]
+            grade_counts[s["grade"]] = grade_counts.get(s["grade"], 0) + 1
+        result["aggregate"] = {
+            "avg_position_counts": {pos: round(t / n, 2) for pos, t in pos_totals.items()},
+            "avg_total_vbd": round(vbd_sum / n, 1),
+            "avg_value_rank": round(rank_sum / n, 2),
+            "grade_distribution": grade_counts,
+        }
+        result["message"] = (
+            f"{n} sims from slot {my_slot}: avg value-rank {result['aggregate']['avg_value_rank']} "
+            f"of {num_teams}, grades {grade_counts}"
+        )
+    else:
+        result["message"] = (
+            f"Mock from slot {my_slot}: grade {sample['grade']} "
+            f"(value-rank {sample['my_value_rank']}/{num_teams}), "
+            f"starters {'filled' if sample['starters_filled'] else 'INCOMPLETE'}"
+        )
+
+    return create_success_response(result)

--- a/nfl_mcp/draft_tools.py
+++ b/nfl_mcp/draft_tools.py
@@ -497,6 +497,33 @@ def _snake_slot(overall_index: int, num_teams: int) -> int:
     return num_teams - pos_in_round
 
 
+def _starting_lineup_value(players: List[Dict], reqs: Dict[str, int]) -> float:
+    """Sum of VBD of a roster's optimal starting lineup (QB/RB/WR/TE + FLEX).
+
+    This is what a draft is really graded on — starters, not deep bench. Bench
+    players (often negative VBD) don't drag the number down.
+    """
+    by_pos: Dict[str, List[float]] = {}
+    for p in players:
+        pos = (p.get("position") or "").upper()
+        if pos in VBD_POSITIONS:
+            by_pos.setdefault(pos, []).append(p.get("vbd") or 0.0)
+    for pos in by_pos:
+        by_pos[pos].sort(reverse=True)
+
+    total = 0.0
+    leftovers: List[float] = []  # flex-eligible players not used as base starters
+    for pos in VBD_POSITIONS:
+        need = reqs.get(pos, 0)
+        vals = by_pos.get(pos, [])
+        total += sum(vals[:need])
+        if pos in ("RB", "WR", "TE"):
+            leftovers.extend(vals[need:])
+    leftovers.sort(reverse=True)
+    total += sum(leftovers[: reqs.get("FLEX", 0)])
+    return round(total, 1)
+
+
 def _grade_from_rank(rank: int, num_teams: int) -> str:
     """Letter grade from a team's value-rank (1 = best) among the league."""
     if num_teams <= 1:
@@ -556,23 +583,27 @@ def _simulate_one(
             "vbd": choice.get("vbd"),
         })
 
-    # Team value totals (sum of VBD) -> standings
+    # Grade on STARTER value (optimal starting lineup), not deep-bench totals.
+    starter_vbd = {s: _starting_lineup_value(rosters[s], reqs) for s in rosters}
     team_vbd = {s: round(sum((r.get("vbd") or 0) for r in rosters[s]), 1) for s in rosters}
-    standings = sorted(team_vbd.items(), key=lambda x: x[1], reverse=True)
+    standings = sorted(starter_vbd.items(), key=lambda x: x[1], reverse=True)
     my_rank = [i + 1 for i, (s, _) in enumerate(standings) if s == my_slot][0]
 
     starters_filled = all(counts[my_slot].get(pos, 0) >= need for pos, need in reqs.items() if pos != "FLEX")
-    my_total_vbd = team_vbd[my_slot]
 
     return {
         "my_team": rosters[my_slot],
         "my_position_counts": counts[my_slot],
-        "my_total_vbd": my_total_vbd,
+        "my_starter_vbd": starter_vbd[my_slot],
+        "my_total_vbd": team_vbd[my_slot],
         "my_total_value": round(sum((r.get("value") or 0) for r in rosters[my_slot]), 0),
         "starters_filled": starters_filled,
         "my_value_rank": my_rank,
         "grade": _grade_from_rank(my_rank, num_teams),
-        "standings": [{"slot": s, "total_vbd": v, "is_me": s == my_slot} for s, v in standings],
+        "standings": [
+            {"slot": s, "starter_vbd": v, "total_vbd": team_vbd[s], "is_me": s == my_slot}
+            for s, v in standings
+        ],
         "rosters_by_slot": {
             s: [f"{r['name']} ({r['position']})" for r in rosters[s]] for s in rosters
         },
@@ -590,7 +621,7 @@ async def simulate_draft(
     scoring: str = "ppr",
     superflex: bool = False,
     dynasty: bool = False,
-    randomness: float = 0.15,
+    randomness: float = 0.35,
     num_sims: int = 1,
     seed: Optional[int] = None,
     db=None,
@@ -598,7 +629,8 @@ async def simulate_draft(
     """Rehearse a full snake draft offline (solo, repeatable).
 
     Opponents pick by need-weighted VBD with realistic ADP noise; your slot
-    picks optimally (same logic as recommend_draft_pick). Note: only QB/RB/WR/TE
+    picks optimally (same logic as recommend_draft_pick). Grading is based on
+    your optimal STARTING lineup value (not deep bench). Note: only QB/RB/WR/TE
     are modeled (no K/DST in the consensus value set).
 
     Args:
@@ -608,7 +640,9 @@ async def simulate_draft(
         scoring: "ppr", "half-ppr", "standard".
         superflex: True for 2-QB / superflex.
         dynasty: Dynasty values vs redraft.
-        randomness: Opponent ADP noise 0..1 (0 = always best available).
+        randomness: Opponent ADP noise 0..1 (default 0.35 ~ realistic human
+            variance; lower makes opponents near-perfect so draft slot dominates,
+            higher makes them erratic so disciplined play always wins).
         num_sims: How many drafts to run. >1 returns aggregate structure.
         seed: Optional RNG seed for reproducibility.
 
@@ -659,18 +693,18 @@ async def simulate_draft(
     if n > 1:
         # Aggregate my roster structure across sims.
         pos_totals: Dict[str, float] = {}
-        vbd_sum = 0.0
+        starter_vbd_sum = 0.0
         rank_sum = 0.0
         grade_counts: Dict[str, int] = {}
         for s in sims:
             for pos, c in s["my_position_counts"].items():
                 pos_totals[pos] = pos_totals.get(pos, 0) + c
-            vbd_sum += s["my_total_vbd"]
+            starter_vbd_sum += s["my_starter_vbd"]
             rank_sum += s["my_value_rank"]
             grade_counts[s["grade"]] = grade_counts.get(s["grade"], 0) + 1
         result["aggregate"] = {
             "avg_position_counts": {pos: round(t / n, 2) for pos, t in pos_totals.items()},
-            "avg_total_vbd": round(vbd_sum / n, 1),
+            "avg_starter_vbd": round(starter_vbd_sum / n, 1),
             "avg_value_rank": round(rank_sum / n, 2),
             "grade_distribution": grade_counts,
         }

--- a/nfl_mcp/draft_tools.py
+++ b/nfl_mcp/draft_tools.py
@@ -524,18 +524,26 @@ def _starting_lineup_value(players: List[Dict], reqs: Dict[str, int]) -> float:
     return round(total, 1)
 
 
-def _grade_from_rank(rank: int, num_teams: int) -> str:
-    """Letter grade from a team's value-rank (1 = best) among the league."""
-    if num_teams <= 1:
+def _grade_from_value(my_value: float, field_values: List[float]) -> str:
+    """Letter grade from where a team's starter value sits in the field's range.
+
+    Distance-based (not ordinal rank): when the field is tightly bunched, being a
+    hair behind shouldn't crater your grade. Grades on the fraction of the
+    realized value spread captured (0 = worst roster, 1 = best roster).
+    """
+    if not field_values:
         return "A"
-    pct = (num_teams - rank) / (num_teams - 1)  # 1.0 best .. 0.0 worst
-    if pct >= 0.85:
+    best, worst = max(field_values), min(field_values)
+    if best <= worst:
         return "A"
-    if pct >= 0.65:
+    pct = (my_value - worst) / (best - worst)
+    if pct >= 0.80:
+        return "A"
+    if pct >= 0.55:
         return "B"
-    if pct >= 0.40:
+    if pct >= 0.30:
         return "C"
-    if pct >= 0.20:
+    if pct >= 0.12:
         return "D"
     return "F"
 
@@ -591,15 +599,21 @@ def _simulate_one(
 
     starters_filled = all(counts[my_slot].get(pos, 0) >= need for pos, need in reqs.items() if pos != "FLEX")
 
+    field_vals = list(starter_vbd.values())
+    best = max(field_vals)
+    my_val = starter_vbd[my_slot]
+    gap_to_best_pct = round((best - my_val) / best * 100, 1) if best else 0.0
+
     return {
         "my_team": rosters[my_slot],
         "my_position_counts": counts[my_slot],
-        "my_starter_vbd": starter_vbd[my_slot],
+        "my_starter_vbd": my_val,
         "my_total_vbd": team_vbd[my_slot],
         "my_total_value": round(sum((r.get("value") or 0) for r in rosters[my_slot]), 0),
         "starters_filled": starters_filled,
         "my_value_rank": my_rank,
-        "grade": _grade_from_rank(my_rank, num_teams),
+        "gap_to_best_pct": gap_to_best_pct,
+        "grade": _grade_from_value(my_val, field_vals),
         "standings": [
             {"slot": s, "starter_vbd": v, "total_vbd": team_vbd[s], "is_me": s == my_slot}
             for s, v in standings
@@ -715,7 +729,8 @@ async def simulate_draft(
     else:
         result["message"] = (
             f"Mock from slot {my_slot}: grade {sample['grade']} "
-            f"(value-rank {sample['my_value_rank']}/{num_teams}), "
+            f"(value-rank {sample['my_value_rank']}/{num_teams}, "
+            f"{sample['gap_to_best_pct']}% behind best), "
             f"starters {'filled' if sample['starters_filled'] else 'INCOMPLETE'}"
         )
 

--- a/nfl_mcp/tool_registry.py
+++ b/nfl_mcp/tool_registry.py
@@ -101,6 +101,7 @@ def get_all_tools() -> List[Callable]:
         # Draft Assistant Tools (VBD board + live pick recommendations)
         get_draft_board,
         recommend_draft_pick,
+        simulate_draft,
 
         # Opponent Analysis Tools
         analyze_opponent,
@@ -919,6 +920,54 @@ async def recommend_draft_pick(
         return {"suggestions": [], "success": False, "error": f"Invalid input: {str(e)}"}
     return await draft_tools.recommend_draft_pick(
         draft_id=draft_id, my_slot=my_slot, num_suggestions=num_suggestions, db=get_db(),
+    )
+
+
+@timing_decorator("simulate_draft", tool_type="draft")
+async def simulate_draft(
+    my_slot: int,
+    num_teams: int = 12,
+    rounds: int = 15,
+    scoring: str = "ppr",
+    superflex: bool = False,
+    dynasty: bool = False,
+    randomness: float = 0.15,
+    num_sims: int = 1,
+    seed: Optional[int] = None,
+) -> dict:
+    """Rehearse a full snake draft offline (solo, repeatable).
+
+    Opponents pick by need-weighted VBD with realistic ADP noise; your slot picks
+    optimally. Great for pre-draft prep: try different slots, see roster structure
+    and a value-based standing. Only QB/RB/WR/TE are modeled (no K/DST).
+
+    Parameters:
+        my_slot (int, required): Your draft position (1..num_teams).
+        num_teams (int): League size (default 12).
+        rounds (int): Number of rounds (default 15).
+        scoring (str): "ppr", "half-ppr", "standard".
+        superflex (bool): True for 2-QB / superflex.
+        dynasty (bool): Dynasty vs redraft values.
+        randomness (float): Opponent ADP noise 0..1 (0 = always best available).
+        num_sims (int): How many drafts to run (>1 returns aggregate structure).
+        seed (int, optional): RNG seed for reproducibility.
+    Returns: {sample:{my_team, standings, grade,...}, aggregate?, format, source, success}
+
+    IMPORTANT FOR LLM AGENTS: Run the simulation and present the result immediately.
+    """
+    try:
+        my_slot = validate_numeric_input(my_slot, min_val=1, max_val=32, required=True)
+        num_teams = validate_numeric_input(num_teams, min_val=2, max_val=32, default=12, required=False)
+        rounds = validate_numeric_input(rounds, min_val=1, max_val=30, default=15, required=False)
+        num_sims = validate_numeric_input(num_sims, min_val=1, max_val=200, default=1, required=False)
+        if seed is not None:
+            seed = validate_numeric_input(seed, min_val=0, max_val=2**31 - 1, required=False)
+    except ValueError as e:
+        return {"sample": None, "success": False, "error": f"Invalid input: {str(e)}"}
+    return await draft_tools.simulate_draft(
+        my_slot=my_slot, num_teams=num_teams, rounds=rounds, scoring=scoring,
+        superflex=superflex, dynasty=dynasty, randomness=randomness,
+        num_sims=num_sims, seed=seed, db=get_db(),
     )
 
 

--- a/nfl_mcp/tool_registry.py
+++ b/nfl_mcp/tool_registry.py
@@ -931,15 +931,16 @@ async def simulate_draft(
     scoring: str = "ppr",
     superflex: bool = False,
     dynasty: bool = False,
-    randomness: float = 0.15,
+    randomness: float = 0.35,
     num_sims: int = 1,
     seed: Optional[int] = None,
 ) -> dict:
     """Rehearse a full snake draft offline (solo, repeatable).
 
     Opponents pick by need-weighted VBD with realistic ADP noise; your slot picks
-    optimally. Great for pre-draft prep: try different slots, see roster structure
-    and a value-based standing. Only QB/RB/WR/TE are modeled (no K/DST).
+    optimally. Graded on your optimal STARTING lineup value. Great for pre-draft
+    prep: try different slots, see roster structure and a value-based standing.
+    Only QB/RB/WR/TE are modeled (no K/DST).
 
     Parameters:
         my_slot (int, required): Your draft position (1..num_teams).
@@ -948,7 +949,7 @@ async def simulate_draft(
         scoring (str): "ppr", "half-ppr", "standard".
         superflex (bool): True for 2-QB / superflex.
         dynasty (bool): Dynasty vs redraft values.
-        randomness (float): Opponent ADP noise 0..1 (0 = always best available).
+        randomness (float): Opponent ADP noise 0..1 (default 0.35 ~ realistic).
         num_sims (int): How many drafts to run (>1 returns aggregate structure).
         seed (int, optional): RNG seed for reproducibility.
     Returns: {sample:{my_team, standings, grade,...}, aggregate?, format, source, success}

--- a/tests/test_draft_tools.py
+++ b/tests/test_draft_tools.py
@@ -141,3 +141,65 @@ class TestRecommendPick:
     async def test_recommend_requires_draft_id(self):
         res = await dt.recommend_draft_pick("", db=_temp_db())
         assert res["success"] is False
+
+
+# A larger pool so a full mock draft can fill starters + bench for all teams
+# without the player pool starving under position caps.
+def _big_pool(n_per_pos=60):
+    pool = []
+    rank = 1
+    for pos, base in (("RB", 10000), ("WR", 9800), ("QB", 6000), ("TE", 5000)):
+        for i in range(n_per_pos):
+            pool.append({
+                "player_id": f"{pos}{i}", "name": f"{pos} Player {i}", "position": pos,
+                "team": "ATL", "value": base - i * 100, "overall_rank": rank,
+                "position_rank": i + 1, "tier": (i // 6) + 1, "trend_30day": 0,
+            })
+            rank += 1
+    return pool
+
+
+class TestSimulateDraft:
+    async def _run(self, db, **kw):
+        svc = _service_with_pool(db)
+        with patch.object(svc, "_fetch_from_fantasycalc", return_value=_big_pool()):
+            return await dt.simulate_draft(db=db, **kw)
+
+    async def test_single_sim_fills_starters(self):
+        db = _temp_db()
+        res = await self._run(db, my_slot=3, num_teams=12, rounds=15, seed=42)
+        assert res["success"] is True
+        sample = res["sample"]
+        assert len(sample["my_team"]) == 15
+        # roster must satisfy starter requirements (QB1/RB2/WR2/TE1)
+        assert sample["starters_filled"] is True
+        counts = sample["my_position_counts"]
+        assert counts.get("QB", 0) >= 1 and counts.get("TE", 0) >= 1
+        # no position wildly over-stacked (caps enforced)
+        assert counts.get("WR", 0) <= 7 and counts.get("RB", 0) <= 7
+        assert 1 <= sample["my_value_rank"] <= 12
+        pv._service = None
+
+    async def test_deterministic_with_seed(self):
+        db = _temp_db()
+        a = await self._run(db, my_slot=5, num_teams=10, seed=7)
+        b = await self._run(db, my_slot=5, num_teams=10, seed=7)
+        assert [r["player_id"] for r in a["sample"]["my_team"]] == \
+               [r["player_id"] for r in b["sample"]["my_team"]]
+        pv._service = None
+
+    async def test_multi_sim_aggregate(self):
+        db = _temp_db()
+        res = await self._run(db, my_slot=1, num_teams=12, num_sims=10, seed=1)
+        assert res["num_sims"] == 10
+        agg = res["aggregate"]
+        assert "avg_position_counts" in agg
+        assert "avg_value_rank" in agg
+        assert sum(agg["grade_distribution"].values()) == 10
+        pv._service = None
+
+    async def test_invalid_slot(self):
+        db = _temp_db()
+        res = await self._run(db, my_slot=20, num_teams=12)
+        assert res["success"] is False
+        pv._service = None


### PR DESCRIPTION
Follow-up to #91 (which merged at P1, before these commits). Adds the offline draft simulator and its grading improvements.

- **simulate_draft**: rehearse a full snake draft offline, solo & repeatable. Opponents pick by need-weighted VBD with realistic ADP noise (default 0.35); your slot picks optimally. Returns your roster, a value-based standing, grade, and aggregate structure over many runs. Reproducible via seed. QB/RB/WR/TE modeled.
- Realistic roster construction: position caps + late-round starter guarantee (no 10-WR teams); stronger shared need-weighting (also improves the live recommend_draft_pick).
- Grading on optimal **starting-lineup** VBD (not deep bench), and a **distance-based grade** (fraction of the field's value spread captured) instead of noisy ordinal rank; reports gap_to_best_pct.
- Tests: fills-starters, determinism, aggregate, validation. Full suite green (763) on 3.11 & 3.12.

🤖 Erstellt mit Claude Code