### PR TITLE
ci: add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     tags: ["v*"]
   pull_request:
     branches: ["main"]
+  workflow_dispatch: {}  # allow manual "build & publish" runs
 
 # Cancel superseded runs on the same ref.
 concurrency:


### PR DESCRIPTION
Adds a manual trigger to the CI pipeline so the build-and-publish job can be run on demand (and works around GitHub not auto-triggering a freshly added workflow on its introducing merge).