### PR TITLE
chore: add Dependabot (pip + github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  # Python dependencies (requirements*.txt + pyproject.toml)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-dependencies:
+        patterns: ["*"]
+    labels: ["dependencies", "python"]
+
+  # GitHub Actions used by the CI pipeline
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns: ["*"]
+    labels: ["dependencies", "ci"]


### PR DESCRIPTION
Weekly, grouped dependency update PRs for Python deps and CI actions. Keeps the fastmcp beta pin and the Node-20 action versions current.