### PR TITLE
docs: project meta (CHANGELOG, CONTRIBUTING, SECURITY, CODEOWNERS)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Code owners for this repository.
+# These owners are requested for review automatically on matching PRs.
+
+# Default owner for everything in the repo
+*                       @gtonic
+
+# CI / build pipeline
+/.github/               @gtonic
+/Dockerfile             @gtonic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.16] - 2026-07-19
+
+### Added
+- **Consensus player values** (`player_values.py`) backed by FantasyCalc (no API
+  key), format-aware (PPR / superflex / league size / dynasty), cached in SQLite
+  and memory. New tools: `get_player_values`, `get_player_value`.
+- **Draft assistant** (`draft_tools.py`):
+  - `get_draft_board` — tiered board ranked by Value-Based Drafting (VBD).
+  - `recommend_draft_pick` — live Sleeper-draft recommendations with roster-need
+    weighting, value-cliff and positional-run detection.
+  - `simulate_draft` — offline snake-draft rehearsal (solo, repeatable) with
+    realistic opponents, starting-lineup grading, and aggregate structure over
+    many runs.
+- **CI/CD pipeline** (`.github/workflows/ci.yml`): pytest on Python 3.11 & 3.12,
+  then build and publish a Docker image to GHCR (`ghcr.io/gtonic/nfl_mcp`) on
+  `main` and version tags; PRs build-only.
+- `.dockerignore` (keeps local state out of the image), Dependabot config,
+  and project docs (`CONTRIBUTING.md`, `SECURITY.md`, `CODEOWNERS`).
+
+### Changed
+- **Trade analyzer** now uses real market values instead of a flat 50-point
+  heuristic; derives the league format from Sleeper settings and flags lopsided
+  trades with value evidence.
+- Matchup and Vegas tools surface fallback/placeholder data honestly (e.g. missing
+  `ODDS_API_KEY`, no live defense data) instead of emitting confident-but-empty
+  recommendations.
+
+### Fixed
+- Green test suite (previously 49 failing): response-schema drift, stale
+  assertions, wrong patch targets, and two real bugs — a waiver `None`-comparison
+  crash and a coaching role-classification substring mismatch.
+- Aligned `requirements.txt` and `pyproject.toml` dependencies; documented
+  `ODDS_API_KEY`; removed a stray dev script.
+
+[Unreleased]: https://github.com/gtonic/nfl_mcp/compare/v0.5.16...HEAD
+[0.5.16]: https://github.com/gtonic/nfl_mcp/releases/tag/v0.5.16

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+Thanks for helping improve the NFL MCP Server!
+
+## Development setup
+
+- Python 3.9+ (CI runs the suite on 3.11 and 3.12)
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt -r requirements-dev.txt
+pip install -e .
+```
+
+## Running things
+
+```bash
+# Tests (with coverage)
+pytest tests/ -q --cov=nfl_mcp --cov-report=term-missing
+
+# Server (HTTP transport on :9000, health at /health)
+python -m nfl_mcp.server
+
+# Docker
+docker build -t nfl-mcp .
+docker run --rm -p 9000:9000 nfl-mcp
+```
+
+## Pull requests
+
+- Branch off `main` and keep each PR focused.
+- Add or update tests — the suite must stay green. `main` is protected and
+  requires the **Tests (3.11)** and **Tests (3.12)** checks to pass before merge.
+- CI builds the Docker image on every PR (validates the Dockerfile); on `main`
+  and `v*` tags it also publishes the image to GHCR.
+- Conventional-style commit prefixes are appreciated: `feat:`, `fix:`, `chore:`,
+  `docs:`, `ci:`, `test:`.
+
+## Releases
+
+- Bump the version in `pyproject.toml`.
+- Create a git tag `vX.Y.Z` (e.g. via `gh release create vX.Y.Z --generate-notes`).
+  The tag triggers CI to publish `ghcr.io/gtonic/nfl_mcp:X.Y.Z` (and `X.Y`).
+
+## Reporting security issues
+
+Please do **not** open public issues for vulnerabilities — see [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported versions
+
+The latest released version (currently the `0.5.x` line) receives security fixes.
+Older versions are not maintained.
+
+## Reporting a vulnerability
+
+Please report security issues **privately** via GitHub's
+[private vulnerability reporting](https://github.com/gtonic/nfl_mcp/security/advisories/new)
+— the repository's **Security** tab → *Report a vulnerability*.
+
+Do **not** open a public issue for security problems.
+
+We aim to acknowledge reports within a few days and will coordinate a fix and a
+disclosure timeline with you.
+
+## Notes on scope
+
+- This server fetches data from third-party services (ESPN, Sleeper, CBS,
+  FantasyCalc, The Odds API) and scrapes some public pages. Treat all fetched
+  content as untrusted input.
+- Input validation, URL/SSRF checks, content sanitization, and outbound rate
+  limiting are built in — see the **Security Considerations** section of the
+  [README](README.md).
+- Optional API keys (e.g. `ODDS_API_KEY`) should be provided via environment
+  variables and never committed.


### PR DESCRIPTION
Adds the standard project docs:
- **CHANGELOG.md** (Keep a Changelog) with the v0.5.16 entry.
- **CONTRIBUTING.md** — dev setup, tests, PR flow, release steps.
- **SECURITY.md** — private vulnerability reporting via GitHub advisories.
- **.github/CODEOWNERS** — @gtonic as default owner.