### PR TITLE
feat: weekly projections + FAAB bid recommender (P2 #1 & #2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Weekly projections** (`projections.py`) — transparent, no scraping/keys:
+  `projected = base_ppg(position rank) × matchup × Vegas game environment × usage
+  × injury`, with floor/ceiling, confidence and a full breakdown. Tools
+  `project_player`, `project_players`. The lineup optimizer now **auto-fills
+  projected points**, so start/sit works without manual point entry.
+- **FAAB bid recommendations** (`faab_tools.py`) — `recommend_faab_bid` turns a
+  waiver claim into a bid (% of budget + absolute) from real market value, the
+  marginal upgrade for your roster, league demand (trending adds), and your
+  remaining budget / weeks left, with a tier and transparent breakdown.
+
 ## [0.5.16] - 2026-07-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -195,10 +195,13 @@ The NFL MCP Server provides **60+ MCP tools** organized into these categories:
 - Draft Data: `get_league_drafts`, `get_draft`, `get_draft_picks`, `get_draft_traded_picks`
 - Global / Meta: `get_nfl_state`, `get_trending_players`, `fetch_all_players` (large players map w/ caching)
 
-#### 🎯 Lineup Optimization (11 tools)
+#### 🎯 Lineup Optimization (13 tools)
 - **Matchup Analysis**: `get_defense_rankings`, `get_matchup_difficulty`, `analyze_roster_matchups`
 - **Start/Sit Recommendations**: `get_start_sit_recommendation`, `get_roster_recommendations`, `compare_players_for_slot`, `analyze_full_lineup`
 - **Vegas Lines**: `get_vegas_lines`, `get_game_environment`, `analyze_roster_vegas`, `get_stack_opportunities`
+- **Weekly Projections**: `project_player`, `project_players` — transparent projections
+  (value × matchup × Vegas environment × usage × injury) with floor/ceiling and a
+  breakdown. Start/sit tools **auto-fill projected points**, so no manual entry needed.
 
 #### 💰 Player Values & Draft Assistant (5 tools)
 Real market-consensus values (FantasyCalc, no API key) power trades and drafting:
@@ -836,7 +839,12 @@ async with Client("http://localhost:9000/mcp/") as client:
 
 ### Waiver Wire Analysis Tools (MCP)
 
-**Tools:** `get_waiver_log`, `check_re_entry_status`, `get_waiver_wire_dashboard`
+**Tools:** `get_waiver_log`, `check_re_entry_status`, `get_waiver_wire_dashboard`, `recommend_faab_bid`
+
+> `recommend_faab_bid(league_id, player_id, my_roster_id)` turns a waiver claim
+> into a data-driven bid (% of FAAB budget + absolute) from the player's real
+> market value, the marginal upgrade for your roster, league demand (trending
+> adds), and your remaining budget / weeks left — with a tier and breakdown.
 
 These advanced tools provide enhanced waiver wire intelligence for fantasy football decision making, addressing common issues like duplicate transaction tracking and identifying volatile players.
 

--- a/nfl_mcp/faab_tools.py
+++ b/nfl_mcp/faab_tools.py
@@ -1,0 +1,222 @@
+"""
+FAAB (Free Agent Acquisition Budget) bid recommendations.
+
+Waiver claims are often where leagues are won or lost, yet most managers bid on
+gut feeling. This turns a bid into a data-driven number by combining:
+
+    - the player's real market value      (player_values / FantasyCalc)
+    - the marginal upgrade for YOUR roster (value over your current starter at
+      that position)
+    - league demand                        (how many managers are adding him -
+      get_trending_players)
+    - budget & timing                      (your remaining FAAB, weeks left)
+
+Output is a recommended bid as a percentage of the total FAAB budget (plus an
+absolute number when the budget is known), a tier, an aggressive/safe range, and
+a transparent breakdown.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from .sleeper_tools import get_league, get_rosters, get_trending_players, get_nfl_state
+from .player_values import get_values_service
+from .trade_analyzer_tools import league_format_from_settings
+from .errors import create_success_response, create_error_response, ErrorType, handle_http_errors
+
+logger = logging.getLogger(__name__)
+
+# Starter slots per position (used to find your replacement-level player).
+_STARTER_SLOTS = {"QB": 1, "RB": 2, "WR": 2, "TE": 1, "K": 1, "DEF": 1, "DST": 1}
+# Regular-season fantasy weeks (playoffs typically start week 15).
+_FANTASY_REGULAR_WEEKS = 14
+# Never recommend blowing more than this share of budget on a single player.
+_MAX_BID_PCT = 75.0
+
+
+def _tier(pct: float) -> str:
+    if pct >= 30:
+        return "must_add"
+    if pct >= 15:
+        return "strong"
+    if pct >= 5:
+        return "solid"
+    if pct >= 1:
+        return "speculative"
+    return "hold_or_stream"
+
+
+@handle_http_errors(default_data={"recommendation": None}, operation_name="recommending FAAB bid")
+async def recommend_faab_bid(
+    league_id: str,
+    player_id: Optional[str] = None,
+    player_name: Optional[str] = None,
+    my_roster_id: Optional[int] = None,
+    db=None,
+) -> Dict:
+    """Recommend a FAAB waiver bid for a player (as % of budget, + absolute).
+
+    Args:
+        league_id: Sleeper league id.
+        player_id: Sleeper player id of the target (preferred).
+        player_name: Player name (fallback lookup).
+        my_roster_id: Your roster id — enables roster-need (marginal upgrade)
+            weighting. Without it, the bid reflects absolute value + demand only.
+
+    Returns: {recommendation: {bid_pct, bid_absolute, range, tier, reasoning,
+              breakdown, ...}, success}
+    """
+    if not player_id and not player_name:
+        return create_error_response("Provide player_id or player_name", ErrorType.VALIDATION,
+                                     {"recommendation": None})
+
+    # --- League format + budget context ---
+    league_res = await get_league(league_id)
+    if not league_res.get("success") or not league_res.get("league"):
+        return create_error_response(f"Could not load league: {league_res.get('error')}",
+                                     ErrorType.HTTP, {"recommendation": None})
+    league = league_res["league"]
+    fmt = league_format_from_settings(league)
+    settings = league.get("settings", {}) or {}
+    total_budget = settings.get("waiver_budget", 0) or 0
+    is_faab = settings.get("waiver_type") == 2 and total_budget > 0
+
+    # --- Values ---
+    service = get_values_service(db)
+    values = await service.get_values(fmt["ppr"], fmt["num_qbs"], fmt["num_teams"], fmt["is_dynasty"])
+    target = service.lookup(values, player_id=player_id, name=player_name)
+    if not target:
+        return create_success_response({
+            "recommendation": None,
+            "is_faab_league": is_faab,
+            "message": (f"'{player_id or player_name}' not in the consensus value list "
+                        "(deep bench / K / DST) — minimal FAAB (0-1%) or a priority claim."),
+        })
+    target_value = float(target.get("value") or 0)
+    position = (target.get("position") or "").upper()
+    max_value = max((float(v.get("value") or 0) for v in values.get("list", [])), default=target_value or 1)
+
+    warnings: List[str] = []
+
+    # --- Marginal upgrade vs your roster ---
+    upgrade = target_value
+    replacement_value = 0.0
+    my_roster = None
+    if my_roster_id is not None:
+        rosters_res = await get_rosters(league_id)
+        for r in (rosters_res.get("rosters", []) if rosters_res.get("success") else []):
+            if r.get("roster_id") == my_roster_id:
+                my_roster = r
+                break
+        if my_roster is not None:
+            my_pos_vals = []
+            for p in my_roster.get("players_enriched", []):
+                if (p.get("position") or "").upper() == position:
+                    v = service.lookup(values, player_id=p.get("player_id"), name=p.get("full_name"))
+                    if v and v.get("value") is not None:
+                        my_pos_vals.append(float(v["value"]))
+            my_pos_vals.sort(reverse=True)
+            slots = _STARTER_SLOTS.get(position, 2)
+            if len(my_pos_vals) >= slots:
+                replacement_value = my_pos_vals[slots - 1]  # your last starter at the position
+            upgrade = max(0.0, target_value - replacement_value)
+            if upgrade <= 0:
+                warnings.append(f"You're already strong at {position} — this is depth, not an upgrade")
+        else:
+            warnings.append(f"Roster {my_roster_id} not found; bidding on absolute value only")
+
+    value_score = min(1.0, target_value / max_value) if max_value else 0.0
+    upgrade_score = min(1.0, (upgrade / target_value)) if target_value else 0.0
+
+    # --- Demand (how contested is he) ---
+    demand_mult = 1.0
+    demand_label = "low"
+    try:
+        trend = await get_trending_players(db, "add", 48, 100)
+        if trend.get("success"):
+            order = [str(tp.get("player_id")) for tp in trend.get("trending_players", [])]
+            pid = str(target.get("player_id"))
+            if pid in order:
+                idx = order.index(pid)
+                if idx < 10:
+                    demand_mult, demand_label = 1.30, "high"
+                elif idx < 30:
+                    demand_mult, demand_label = 1.15, "moderate"
+                else:
+                    demand_mult, demand_label = 1.05, "light"
+    except Exception as e:
+        logger.debug(f"trending fetch failed: {e}")
+
+    # --- Timing (weeks left) ---
+    timing_mult = 1.0
+    weeks_left = None
+    try:
+        state = await get_nfl_state()
+        wk = state.get("nfl_state", {}).get("week") if state.get("success") else None
+        if wk:
+            weeks_left = max(0, _FANTASY_REGULAR_WEEKS - int(wk))
+            if weeks_left <= 3:
+                timing_mult = 1.2  # spend it before playoffs
+                warnings.append("Few weeks left — spend aggressively if contending")
+    except Exception:
+        pass
+
+    # --- Bid model ---
+    base_pct = 100.0 * value_score * (0.5 + 0.5 * upgrade_score)
+    bid_pct = round(min(_MAX_BID_PCT, base_pct * demand_mult * timing_mult), 1)
+    tier = _tier(bid_pct)
+
+    # Budget context
+    remaining_budget = None
+    bid_absolute = None
+    aggressive_abs = safe_abs = None
+    if is_faab:
+        used = (my_roster.get("settings", {}) or {}).get("waiver_budget_used") if my_roster else None
+        remaining_budget = (total_budget - used) if used is not None else total_budget
+        bid_absolute = round(bid_pct / 100.0 * total_budget)
+        if remaining_budget is not None:
+            bid_absolute = min(bid_absolute, remaining_budget)
+            if bid_absolute >= remaining_budget * 0.9 and remaining_budget > 0:
+                warnings.append("This would use most of your remaining budget")
+        aggressive_abs = min(round(bid_pct * 1.25 / 100.0 * total_budget), remaining_budget or 10**9)
+        safe_abs = round(bid_pct * 0.7 / 100.0 * total_budget)
+    else:
+        warnings.append("Not a FAAB league (waiver priority) — use your claim priority instead of a $ bid")
+
+    reasoning = [
+        f"Market value {int(target_value)} ({position} #{target.get('position_rank')})",
+        (f"Marginal upgrade for you: +{int(upgrade)} over your replacement ({int(replacement_value)})"
+         if my_roster_id is not None else "No roster context — absolute value used"),
+        f"League demand: {demand_label}",
+    ]
+    if weeks_left is not None:
+        reasoning.append(f"{weeks_left} regular-season weeks left")
+
+    return create_success_response({
+        "recommendation": {
+            "player": target.get("name"),
+            "position": position,
+            "bid_pct": bid_pct,
+            "bid_absolute": bid_absolute,
+            "range_pct": {"safe": round(bid_pct * 0.7, 1), "aggressive": round(min(_MAX_BID_PCT, bid_pct * 1.25), 1)},
+            "range_absolute": {"safe": safe_abs, "aggressive": aggressive_abs},
+            "tier": tier,
+            "reasoning": reasoning,
+            "warnings": warnings,
+            "breakdown": {
+                "value_score": round(value_score, 3),
+                "upgrade_score": round(upgrade_score, 3),
+                "demand_mult": demand_mult,
+                "timing_mult": timing_mult,
+                "base_pct": round(base_pct, 1),
+            },
+        },
+        "is_faab_league": is_faab,
+        "total_budget": total_budget if is_faab else None,
+        "remaining_budget": remaining_budget,
+        "message": (f"Bid ~{bid_pct}% "
+                    + (f"(${bid_absolute} of {total_budget}) " if bid_absolute is not None else "")
+                    + f"on {target.get('name')} [{tier}]"),
+    })

--- a/nfl_mcp/lineup_optimizer_tools.py
+++ b/nfl_mcp/lineup_optimizer_tools.py
@@ -160,10 +160,15 @@ class LineupOptimizer:
     Uses a weighted scoring system to calculate confidence in recommendations.
     """
     
-    def __init__(self, db=None, defense_analyzer=None):
-        """Initialize the optimizer with optional database and analyzer."""
+    def __init__(self, db=None, defense_analyzer=None, auto_project=True):
+        """Initialize the optimizer with optional database and analyzer.
+
+        auto_project: when True, fill projected points from the internal
+        projection engine whenever the caller doesn't supply them.
+        """
         self.db = db
         self.defense_analyzer = defense_analyzer
+        self.auto_project = auto_project
         self._init_dependencies()
     
     def _init_dependencies(self):
@@ -395,11 +400,29 @@ class LineupOptimizer:
             analysis.injury_status = injury_data.get("status", "healthy")
             analysis.practice_status = injury_data.get("practice_status", "full")
         
-        # Apply projection data
-        if projection_data:
+        # Apply projection data — or auto-project when the caller didn't supply
+        # points, so start/sit works without manual point entry.
+        if projection_data and projection_data.get("projected_points"):
             analysis.projected_points = projection_data.get("projected_points", 0.0)
             analysis.floor = projection_data.get("floor", 0.0)
             analysis.ceiling = projection_data.get("ceiling", 0.0)
+        elif self.auto_project:
+            try:
+                from .projections import get_projection_engine
+                engine = get_projection_engine(self.db)
+                pr = await engine.project_many([{
+                    "name": player_name, "player_id": player_id,
+                    "position": position.upper(), "team": team.upper(),
+                    "opponent": opponent.upper(),
+                    "usage": usage_data or {}, "injury": injury_data or {},
+                }])
+                if pr.get("projections"):
+                    pp = pr["projections"][0]
+                    analysis.projected_points = pp["projected_points"]
+                    analysis.floor = pp["floor"]
+                    analysis.ceiling = pp["ceiling"]
+            except Exception as e:
+                logger.debug(f"Auto-projection failed for {player_name}: {e}")
         
         # Calculate confidence and decision
         confidence, confidence_level, reasoning = self.calculate_confidence(analysis)

--- a/nfl_mcp/projections.py
+++ b/nfl_mcp/projections.py
@@ -1,0 +1,285 @@
+"""
+Transparent weekly fantasy point projections.
+
+Instead of scraping a fragile third-party page, this builds a projection from
+signals the server already has:
+
+    projected = base_ppg(position_rank)   # talent/role baseline (FantasyCalc rank)
+              × matchup_multiplier         # defense vs position (matchup_tools)
+              × environment_multiplier      # Vegas implied team total (vegas_tools)
+              × usage_multiplier            # snap% / usage trend (enrichment)
+              × injury_multiplier           # availability
+
+Every factor is reported in a `breakdown` so the number is explainable, and a
+`confidence` reflects how many real signals were available. No API key needed
+(FantasyCalc + ESPN); Vegas is optional (ODDS_API_KEY improves it).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from .player_values import get_values_service, scoring_to_ppr
+from .matchup_tools import get_defense_analyzer
+from .vegas_tools import get_vegas_analyzer
+from .errors import create_success_response, create_error_response, ErrorType, handle_http_errors
+
+logger = logging.getLogger(__name__)
+
+VBD_POSITIONS = {"QB", "RB", "WR", "TE"}
+
+
+def base_ppg(position: str, pos_rank: Optional[int]) -> float:
+    """Baseline PPR points/game from a player's positional rank."""
+    p = (position or "").upper()
+    r = pos_rank if (isinstance(pos_rank, int) and pos_rank > 0) else 999
+    if p == "QB":
+        return 22.0 if r <= 3 else 20.0 if r <= 8 else 18.0 if r <= 12 else 16.0 if r <= 20 else 14.0
+    if p == "RB":
+        return 19.0 if r <= 3 else 16.0 if r <= 8 else 13.0 if r <= 15 else 11.0 if r <= 24 else 8.5 if r <= 36 else 6.0
+    if p == "WR":
+        return 17.0 if r <= 5 else 14.5 if r <= 12 else 12.0 if r <= 24 else 9.5 if r <= 36 else 7.5 if r <= 48 else 5.5
+    if p == "TE":
+        return 14.0 if r <= 3 else 11.0 if r <= 6 else 8.5 if r <= 12 else 6.5 if r <= 20 else 5.0
+    if p == "K":
+        return 8.0
+    if p in ("DST", "DEF"):
+        return 7.0
+    return 8.0
+
+
+_MATCHUP_MULT = {"smash": 1.10, "favorable": 1.05, "neutral": 1.0,
+                 "tough": 0.95, "elite": 0.90, "unknown": 1.0}
+
+# Higher fantasy scoring variance = wider floor/ceiling band.
+_VOLATILITY = {"QB": 0.22, "RB": 0.30, "WR": 0.38, "TE": 0.40, "K": 0.35, "DST": 0.45, "DEF": 0.45}
+
+
+def _environment_mult(implied_total: Optional[float], is_fallback: bool) -> float:
+    if is_fallback or implied_total is None:
+        return 1.0
+    if implied_total >= 28:
+        return 1.08
+    if implied_total >= 25:
+        return 1.04
+    if implied_total >= 21:
+        return 1.0
+    if implied_total >= 18:
+        return 0.96
+    return 0.92
+
+
+def _usage_mult(snap_pct: Optional[float], usage_trend: Optional[str]) -> float:
+    mult = 1.0
+    if snap_pct:
+        if snap_pct >= 80:
+            mult *= 1.05
+        elif snap_pct < 40:
+            mult *= 0.92
+    t = (usage_trend or "").lower()
+    if t in ("up", "upward"):
+        mult *= 1.05
+    elif t in ("down", "downward"):
+        mult *= 0.95
+    return mult
+
+
+def _injury_mult(status: Optional[str]) -> float:
+    s = (status or "").lower()
+    if s in ("out", "ir", "suspended", "pup", "injured reserve"):
+        return 0.0
+    if s == "doubtful":
+        return 0.35
+    if s == "questionable":
+        return 0.9
+    return 1.0
+
+
+class ProjectionEngine:
+    """Projects fantasy points by combining value, matchup, environment, usage."""
+
+    def __init__(self, db=None):
+        self.values = get_values_service(db)
+        self.defense = get_defense_analyzer()
+        self.vegas = get_vegas_analyzer()
+
+    def _project_one(self, player: Dict, values_index: Dict, rankings: Dict, lines: Dict) -> Dict:
+        name = player.get("name") or player.get("player_name")
+        position = (player.get("position") or "").upper()
+        team = (player.get("team") or "").upper()
+        opponent = (player.get("opponent") or "").upper()
+        player_id = player.get("player_id")
+        usage = player.get("usage") or {}
+        injury = player.get("injury") or {}
+
+        # 1) Baseline from positional rank (real market data when available)
+        market = self.values.lookup(values_index, player_id=player_id, name=name, position=position)
+        pos_rank = (market or {}).get("position_rank")
+        base = base_ppg(position, pos_rank)
+
+        # 2) Matchup vs opponent defense
+        matchup_tier = "unknown"
+        if position in VBD_POSITIONS and opponent:
+            try:
+                m = self.defense.get_matchup_difficulty(position, opponent, rankings)
+                matchup_tier = m.get("matchup_tier", "unknown")
+            except Exception:
+                matchup_tier = "unknown"
+        matchup_mult = _MATCHUP_MULT.get(matchup_tier, 1.0)
+
+        # 3) Game environment (Vegas implied team total)
+        implied_total = None
+        env_is_fallback = True
+        if team:
+            try:
+                game = self.vegas.get_game_lines(team, lines)
+                is_home = game.get("home_team") == team
+                implied_total = game.get("home_implied_total") if is_home else game.get("away_implied_total")
+                env_is_fallback = bool(game.get("is_fallback"))
+            except Exception:
+                pass
+        env_mult = _environment_mult(implied_total, env_is_fallback)
+
+        # 4) Usage & 5) injury
+        usage_mult = _usage_mult(usage.get("snap_percentage"), usage.get("usage_trend"))
+        inj_mult = _injury_mult(injury.get("status"))
+
+        projected = round(base * matchup_mult * env_mult * usage_mult * inj_mult, 1)
+        vol = _VOLATILITY.get(position, 0.35)
+        if inj_mult == 0.0:
+            floor = ceiling = 0.0
+        else:
+            floor = round(projected * (1 - vol), 1)
+            ceiling = round(projected * (1 + vol), 1)
+
+        # Confidence = how many real signals we had
+        conf = 50
+        if market:
+            conf += 20
+        if not env_is_fallback:
+            conf += 15
+        if usage:
+            conf += 15
+        conf = min(conf, 100)
+        conf_level = "high" if conf >= 80 else "medium" if conf >= 60 else "low"
+
+        return {
+            "player": name,
+            "position": position,
+            "team": team,
+            "opponent": opponent,
+            "projected_points": projected,
+            "floor": floor,
+            "ceiling": ceiling,
+            "confidence": conf,
+            "confidence_level": conf_level,
+            "matchup_tier": matchup_tier,
+            "implied_total": implied_total,
+            "breakdown": {
+                "base_ppg": base,
+                "position_rank": pos_rank,
+                "matchup_mult": round(matchup_mult, 3),
+                "environment_mult": round(env_mult, 3),
+                "usage_mult": round(usage_mult, 3),
+                "injury_mult": round(inj_mult, 3),
+            },
+            "value_source": "fantasycalc" if market else "baseline",
+        }
+
+    async def project_many(
+        self, players: List[Dict], scoring: str = "ppr", superflex: bool = False, num_teams: int = 12
+    ) -> Dict:
+        values_index = await self.values.get_values(
+            scoring_to_ppr(scoring), 2 if superflex else 1, num_teams, False
+        )
+        try:
+            rankings = await self.defense.fetch_defense_rankings()
+        except Exception:
+            rankings = {}
+        try:
+            lines = await self.vegas.fetch_current_lines()
+        except Exception:
+            lines = {}
+        projections = [self._project_one(p, values_index, rankings, lines) for p in players]
+        return {
+            "projections": projections,
+            "values_source": values_index.get("source"),
+            "vegas_active": bool(lines),
+        }
+
+
+_engine: Optional[ProjectionEngine] = None
+
+
+def get_projection_engine(db=None) -> ProjectionEngine:
+    global _engine
+    if _engine is None:
+        _engine = ProjectionEngine(db=db)
+    return _engine
+
+
+# ==========================================================================
+# MCP Tool Functions
+# ==========================================================================
+
+@handle_http_errors(default_data={"projections": []}, operation_name="projecting players")
+async def project_players(
+    players: List[Dict],
+    scoring: str = "ppr",
+    superflex: bool = False,
+    num_teams: int = 12,
+    db=None,
+) -> Dict:
+    """Project weekly fantasy points for multiple players (transparent, no scraping).
+
+    Args:
+        players: list of dicts with name, position, team, opponent, and optional
+            usage {snap_percentage, usage_trend} and injury {status}.
+        scoring/superflex/num_teams: league format for the value baseline.
+
+    Returns: {projections:[{projected_points, floor, ceiling, confidence, breakdown, ...}]}
+    """
+    if not players:
+        return create_error_response("No players provided", ErrorType.VALIDATION, {"projections": []})
+    engine = get_projection_engine(db)
+    result = await engine.project_many(players, scoring=scoring, superflex=superflex, num_teams=num_teams)
+    return create_success_response({
+        **result,
+        "total": len(result["projections"]),
+        "message": f"Projected {len(result['projections'])} players ({result.get('values_source')})",
+    })
+
+
+@handle_http_errors(default_data={"projection": None}, operation_name="projecting player")
+async def project_player(
+    player_name: str,
+    position: str,
+    team: str,
+    opponent: str,
+    snap_percentage: Optional[float] = None,
+    usage_trend: Optional[str] = None,
+    injury_status: Optional[str] = None,
+    scoring: str = "ppr",
+    superflex: bool = False,
+    db=None,
+) -> Dict:
+    """Project weekly fantasy points for a single player.
+
+    Returns: {projection: {projected_points, floor, ceiling, confidence, breakdown, ...}}
+    """
+    player = {
+        "name": player_name, "position": position, "team": team, "opponent": opponent,
+        "usage": {"snap_percentage": snap_percentage, "usage_trend": usage_trend},
+        "injury": {"status": injury_status},
+    }
+    engine = get_projection_engine(db)
+    result = await engine.project_many([player], scoring=scoring, superflex=superflex)
+    proj = result["projections"][0] if result["projections"] else None
+    return create_success_response({
+        "projection": proj,
+        "values_source": result.get("values_source"),
+        "message": (f"{player_name}: {proj['projected_points']} pts "
+                    f"(floor {proj['floor']}, ceiling {proj['ceiling']}, {proj['confidence_level']} conf)"
+                    if proj else "No projection"),
+    })

--- a/nfl_mcp/tool_registry.py
+++ b/nfl_mcp/tool_registry.py
@@ -12,7 +12,7 @@ from typing import Optional, List, Callable, Any
 import json
 import httpx
 from .metrics import timing_decorator
-from . import nfl_tools, sleeper_tools, waiver_tools, web_tools, athlete_tools, trade_analyzer_tools, cbs_fantasy_tools, opponent_analysis_tools, matchup_tools, lineup_optimizer_tools, vegas_tools, coaching_tools, player_values, draft_tools
+from . import nfl_tools, sleeper_tools, waiver_tools, web_tools, athlete_tools, trade_analyzer_tools, cbs_fantasy_tools, opponent_analysis_tools, matchup_tools, lineup_optimizer_tools, vegas_tools, coaching_tools, player_values, draft_tools, projections, faab_tools
 from .config import FEATURE_LEAGUE_LEADERS, validate_string_input, validate_limit, validate_numeric_input, LIMITS
 from .database import NFLDatabase
 
@@ -90,6 +90,7 @@ def get_all_tools() -> List[Callable]:
         get_waiver_log,
         check_re_entry_status,
         get_waiver_wire_dashboard,
+        recommend_faab_bid,
         
         # Trade Analyzer Tools
         analyze_trade,
@@ -102,6 +103,10 @@ def get_all_tools() -> List[Callable]:
         get_draft_board,
         recommend_draft_pick,
         simulate_draft,
+
+        # Projection Tools (transparent weekly projections)
+        project_player,
+        project_players,
 
         # Opponent Analysis Tools
         analyze_opponent,
@@ -710,6 +715,39 @@ async def get_waiver_wire_dashboard(league_id: str, round: Optional[int] = None)
         return {"dashboard": {}, "league_id": league_id, "round": round, "success": False, "error": f"Invalid input: {str(e)}"}
 
 
+@timing_decorator("recommend_faab_bid", tool_type="waiver")
+async def recommend_faab_bid(
+    league_id: str,
+    player_id: Optional[str] = None,
+    player_name: Optional[str] = None,
+    my_roster_id: Optional[int] = None,
+) -> dict:
+    """Recommend a FAAB waiver bid for a player (% of budget + absolute).
+
+    Combines the player's real market value, the marginal upgrade for your roster,
+    league demand (trending adds), and your remaining budget / weeks left.
+
+    Parameters:
+        league_id (str, required): Sleeper league id.
+        player_id (str, optional): Sleeper player id of the target (preferred).
+        player_name (str, optional): Player name (fallback lookup).
+        my_roster_id (int, optional): Your roster id for roster-need weighting.
+    Returns: {recommendation:{bid_pct, bid_absolute, tier, range, reasoning, breakdown}, success}
+
+    IMPORTANT FOR LLM AGENTS: Provide the bid recommendation immediately without asking for confirmation.
+    """
+    try:
+        league_id = validate_string_input(league_id, 'league_id', max_length=50, required=True)
+        if my_roster_id is not None:
+            my_roster_id = validate_numeric_input(my_roster_id, min_val=1, max_val=32, required=False)
+    except ValueError as e:
+        return {"recommendation": None, "success": False, "error": f"Invalid input: {str(e)}"}
+    return await faab_tools.recommend_faab_bid(
+        league_id=league_id, player_id=player_id, player_name=player_name,
+        my_roster_id=my_roster_id, db=get_db(),
+    )
+
+
 # =============================================================================
 # TRADE ANALYZER TOOLS
 # =============================================================================
@@ -969,6 +1007,71 @@ async def simulate_draft(
         my_slot=my_slot, num_teams=num_teams, rounds=rounds, scoring=scoring,
         superflex=superflex, dynasty=dynasty, randomness=randomness,
         num_sims=num_sims, seed=seed, db=get_db(),
+    )
+
+
+# =============================================================================
+# PROJECTION TOOLS (transparent weekly fantasy point projections)
+# =============================================================================
+
+@timing_decorator("project_player", tool_type="projection")
+async def project_player(
+    player_name: str,
+    position: str,
+    team: str,
+    opponent: str,
+    snap_percentage: Optional[float] = None,
+    usage_trend: Optional[str] = None,
+    injury_status: Optional[str] = None,
+    scoring: str = "ppr",
+    superflex: bool = False,
+) -> dict:
+    """Project weekly fantasy points for one player (transparent, no scraping).
+
+    Combines market-value baseline × matchup × Vegas game environment × usage ×
+    injury into a projection with floor/ceiling, confidence and a full breakdown.
+
+    Parameters:
+        player_name, position (QB/RB/WR/TE), team, opponent (all required abbreviations).
+        snap_percentage (float, optional), usage_trend ("up"/"down", optional),
+        injury_status (optional), scoring ("ppr"/"half-ppr"/"standard"), superflex (bool).
+    Returns: {projection:{projected_points, floor, ceiling, confidence, breakdown,...}, success}
+    """
+    try:
+        player_name = validate_string_input(player_name, 'player_name', max_length=100, required=True)
+        position = validate_string_input(position, 'position', max_length=5, required=True)
+        team = validate_string_input(team, 'team', max_length=5, required=True)
+        opponent = validate_string_input(opponent, 'opponent', max_length=5, required=True)
+    except ValueError as e:
+        return {"projection": None, "success": False, "error": f"Invalid input: {str(e)}"}
+    return await projections.project_player(
+        player_name=player_name, position=position.upper(), team=team.upper(),
+        opponent=opponent.upper(), snap_percentage=snap_percentage, usage_trend=usage_trend,
+        injury_status=injury_status, scoring=scoring, superflex=superflex, db=get_db(),
+    )
+
+
+@timing_decorator("project_players", tool_type="projection")
+async def project_players(
+    players: List[dict],
+    scoring: str = "ppr",
+    superflex: bool = False,
+    num_teams: int = 12,
+) -> dict:
+    """Project weekly fantasy points for multiple players at once.
+
+    Parameters:
+        players (list, required): dicts with name, position, team, opponent and
+            optional usage {snap_percentage, usage_trend} and injury {status}.
+        scoring/superflex/num_teams: league format for the value baseline.
+    Returns: {projections:[...], total, success}
+
+    IMPORTANT FOR LLM AGENTS: Return projections immediately without asking for confirmation.
+    """
+    if not players:
+        return {"projections": [], "total": 0, "success": False, "error": "No players provided"}
+    return await projections.project_players(
+        players=players, scoring=scoring, superflex=superflex, num_teams=num_teams, db=get_db(),
     )
 
 

--- a/tests/test_faab_tools.py
+++ b/tests/test_faab_tools.py
@@ -1,0 +1,102 @@
+"""Tests for the FAAB bid recommender (offline, mocked Sleeper + values)."""
+
+import pytest
+from unittest.mock import patch
+
+from nfl_mcp import faab_tools as ft
+
+
+class FakeService:
+    def __init__(self, by_id):
+        self._by_id = {str(k): v for k, v in by_id.items()}
+
+    async def get_values(self, *a, **k):
+        return {"source": "fantasycalc", "list": list(self._by_id.values())}
+
+    def lookup(self, idx, player_id=None, name=None, position=None):
+        return self._by_id.get(str(player_id)) or next(
+            (v for v in self._by_id.values() if v.get("name") == name), None)
+
+
+def _league(faab=True, budget=100):
+    return {"success": True, "league": {
+        "scoring_settings": {"rec": 1.0},
+        "roster_positions": ["QB", "RB", "RB", "WR", "WR", "TE", "FLEX", "BN", "BN"],
+        "total_rosters": 12,
+        "settings": {"type": 0, "waiver_type": 2 if faab else 0, "waiver_budget": budget},
+    }}
+
+
+# Target: elite RB (value 10000, RB#1). Some other RBs for "redundant" case.
+VALUES = {
+    "9509": {"player_id": "9509", "name": "Bijan Robinson", "position": "RB", "value": 10000, "position_rank": 1},
+    "elite1": {"player_id": "elite1", "name": "Elite RB A", "position": "RB", "value": 9500, "position_rank": 2},
+    "elite2": {"player_id": "elite2", "name": "Elite RB B", "position": "RB", "value": 9300, "position_rank": 3},
+    "weak": {"player_id": "weak", "name": "Weak RB", "position": "RB", "value": 800, "position_rank": 60},
+}
+
+
+def _patches(league, rosters, trending_ids, week=10):
+    async def L(l): return league
+    async def R(l): return rosters
+    async def T(db, a, b, c): return {"success": True, "trending_players": [{"player_id": p, "count": 999} for p in trending_ids]}
+    async def S(): return {"success": True, "nfl_state": {"week": week}}
+    return [
+        patch.object(ft, "get_league", L),
+        patch.object(ft, "get_rosters", R),
+        patch.object(ft, "get_trending_players", T),
+        patch.object(ft, "get_nfl_state", S),
+        patch.object(ft, "get_values_service", lambda db=None: FakeService(VALUES)),
+    ]
+
+
+async def _run(**kwargs):
+    league = kwargs.pop("league", _league())
+    rosters = kwargs.pop("rosters", {"success": True, "rosters": []})
+    trending = kwargs.pop("trending", ["9509"])
+    import contextlib
+    with contextlib.ExitStack() as stack:
+        for p in _patches(league, rosters, trending):
+            stack.enter_context(p)
+        return await ft.recommend_faab_bid(**kwargs)
+
+
+class TestFaab:
+    async def test_elite_add_thin_roster_is_must_add(self):
+        rosters = {"success": True, "rosters": [
+            {"roster_id": 1, "players_enriched": [{"player_id": "weak", "full_name": "Weak RB", "position": "RB"}],
+             "settings": {"waiver_budget_used": 20}}]}
+        res = await _run(league_id="1", player_id="9509", my_roster_id=1, rosters=rosters)
+        r = res["recommendation"]
+        assert res["is_faab_league"] is True
+        assert r["tier"] == "must_add"
+        assert r["bid_pct"] >= 30
+        assert r["bid_absolute"] is not None
+        assert res["remaining_budget"] == 80
+
+    async def test_redundant_add_is_cheaper_and_warns(self):
+        # I roster two RBs better than the target -> it's depth, not an upgrade.
+        rosters = {"success": True, "rosters": [
+            {"roster_id": 1, "players_enriched": [
+                {"player_id": "9509", "full_name": "Bijan Robinson", "position": "RB"},
+                {"player_id": "elite1", "full_name": "Elite RB A", "position": "RB"},
+            ], "settings": {"waiver_budget_used": 0}}]}
+        # Target the weaker RB (value 9300, below my last starter 9500).
+        res = await _run(league_id="1", player_id="elite2", my_roster_id=1, rosters=rosters)
+        r = res["recommendation"]
+        assert r["breakdown"]["upgrade_score"] == 0.0   # no upgrade
+        assert any("strong at RB" in w for w in r["warnings"])
+
+    async def test_non_faab_league(self):
+        res = await _run(league_id="1", player_id="9509", league=_league(faab=False))
+        assert res["is_faab_league"] is False
+        assert any("Not a FAAB" in w for w in res["recommendation"]["warnings"])
+
+    async def test_player_not_in_values(self):
+        res = await _run(league_id="1", player_id="unknown_id")
+        assert res["recommendation"] is None
+        assert "consensus value list" in res["message"]
+
+    async def test_requires_player(self):
+        res = await ft.recommend_faab_bid(league_id="1", db=None)
+        assert res["success"] is False

--- a/tests/test_lineup_optimizer_tools.py
+++ b/tests/test_lineup_optimizer_tools.py
@@ -318,3 +318,42 @@ class TestAnalyzeFullLineup:
         
         assert result["success"] is True
         assert "starters" in result
+
+
+class TestAutoProjection:
+    """The optimizer fills projected points itself when the caller doesn't."""
+
+    def _fresh_defense(self):
+        # Own analyzer instance (NOT the global singleton) with a no-network fetch,
+        # so mutating it can't leak into other tests.
+        from unittest.mock import AsyncMock
+        from nfl_mcp.matchup_tools import DefenseRankingsAnalyzer
+        da = DefenseRankingsAnalyzer(db=None)
+        da.fetch_defense_rankings = AsyncMock(return_value={})
+        return da
+
+    @pytest.mark.asyncio
+    async def test_analyze_player_auto_projects(self):
+        from unittest.mock import patch
+        from nfl_mcp import lineup_optimizer_tools as lo
+
+        opt = lo.LineupOptimizer(db=None, auto_project=True, defense_analyzer=self._fresh_defense())
+
+        class FakeEngine:
+            async def project_many(self, players):
+                return {"projections": [{"projected_points": 18.5, "floor": 12.0, "ceiling": 25.0}]}
+
+        with patch("nfl_mcp.projections.get_projection_engine", return_value=FakeEngine()):
+            analysis = await opt.analyze_player("Some WR", "", "WR", "MIA", "NE")
+
+        assert analysis.projected_points == 18.5
+        assert analysis.floor == 12.0
+        assert analysis.ceiling == 25.0
+
+    @pytest.mark.asyncio
+    async def test_auto_project_disabled_leaves_zero(self):
+        from nfl_mcp import lineup_optimizer_tools as lo
+
+        opt = lo.LineupOptimizer(db=None, auto_project=False, defense_analyzer=self._fresh_defense())
+        analysis = await opt.analyze_player("Some WR", "", "WR", "MIA", "NE")
+        assert analysis.projected_points == 0.0

--- a/tests/test_projections.py
+++ b/tests/test_projections.py
@@ -1,0 +1,104 @@
+"""Tests for the weekly projection engine (offline, no network)."""
+
+import pytest
+
+from nfl_mcp import projections as pj
+
+
+class FakeValues:
+    def __init__(self, by_id=None, by_name=None):
+        self._by_id = by_id or {}
+        self._by_name = by_name or {}
+
+    async def get_values(self, *a, **k):
+        return {"source": "fantasycalc", "list": list(self._by_id.values())}
+
+    def lookup(self, idx, player_id=None, name=None, position=None):
+        return self._by_id.get(str(player_id)) or self._by_name.get(name)
+
+
+class FakeDefense:
+    def __init__(self, tier="neutral"):
+        self.tier = tier
+
+    async def fetch_defense_rankings(self):
+        return {}
+
+    def get_matchup_difficulty(self, position, opponent, rankings):
+        return {"matchup_tier": self.tier, "rank": 16}
+
+
+class FakeVegas:
+    def __init__(self, lines=None):
+        self._lines = lines or {}
+
+    async def fetch_current_lines(self):
+        return self._lines
+
+    def get_game_lines(self, team, lines):
+        return (lines or self._lines).get(team, {"home_team": team, "is_fallback": True})
+
+
+def _engine(values=None, defense=None, vegas=None):
+    e = pj.ProjectionEngine.__new__(pj.ProjectionEngine)  # skip __init__ (no singletons)
+    e.values = values or FakeValues()
+    e.defense = defense or FakeDefense()
+    e.vegas = vegas or FakeVegas()
+    return e
+
+
+class TestPureHelpers:
+    def test_base_ppg_tiers(self):
+        assert pj.base_ppg("RB", 1) > pj.base_ppg("RB", 20) > pj.base_ppg("RB", 40)
+        assert pj.base_ppg("WR", 1) == 17.0
+        assert pj.base_ppg("QB", 2) == 22.0
+        # unknown rank -> lowest tier
+        assert pj.base_ppg("TE", None) == pj.base_ppg("TE", 999)
+
+    def test_environment_mult(self):
+        assert pj._environment_mult(29, False) > 1.0
+        assert pj._environment_mult(17, False) < 1.0
+        assert pj._environment_mult(29, True) == 1.0   # fallback -> neutral
+        assert pj._environment_mult(None, False) == 1.0
+
+    def test_usage_and_injury_mult(self):
+        assert pj._usage_mult(90, "up") > pj._usage_mult(30, "down")
+        assert pj._injury_mult("out") == 0.0
+        assert pj._injury_mult("questionable") == 0.9
+        assert pj._injury_mult(None) == 1.0
+
+
+class TestProjectMany:
+    async def test_smash_and_environment_boost(self):
+        vals = FakeValues(by_name={"WR One": {"value": 9000, "position_rank": 3, "position": "WR"}})
+        vegas = FakeVegas({"CIN": {"home_team": "CIN", "home_implied_total": 29, "is_fallback": False}})
+        eng = _engine(vals, FakeDefense("smash"), vegas)
+        res = await eng.project_many([{"name": "WR One", "position": "WR", "team": "CIN", "opponent": "CLE",
+                                       "usage": {"snap_percentage": 90, "usage_trend": "up"}}])
+        p = res["projections"][0]
+        # base 17 (rank<=5) * smash 1.10 * env 1.08 * usage(1.05*1.05) > base
+        assert p["projected_points"] > 17.0
+        assert p["floor"] < p["projected_points"] < p["ceiling"]
+        assert p["confidence"] >= 80  # value + real vegas + usage
+        assert p["matchup_tier"] == "smash"
+
+    async def test_injury_out_zeroes_projection(self):
+        vals = FakeValues(by_name={"Hurt Guy": {"value": 5000, "position_rank": 10, "position": "RB"}})
+        eng = _engine(vals)
+        res = await eng.project_many([{"name": "Hurt Guy", "position": "RB", "team": "KC", "opponent": "LV",
+                                       "injury": {"status": "out"}}])
+        p = res["projections"][0]
+        assert p["projected_points"] == 0.0
+        assert p["floor"] == 0.0 and p["ceiling"] == 0.0
+
+    async def test_unknown_player_uses_baseline(self):
+        eng = _engine()  # empty values -> lookup misses
+        res = await eng.project_many([{"name": "Nobody", "position": "WR", "team": "NYJ", "opponent": "BUF"}])
+        p = res["projections"][0]
+        assert p["value_source"] == "baseline"
+        assert p["projected_points"] > 0
+        assert p["confidence"] == 50  # no real signals
+
+    async def test_tool_project_players_empty(self):
+        res = await pj.project_players([], db=None)
+        assert res["success"] is False


### PR DESCRIPTION
Implements the two P2 ideas, both built on the consensus value layer.

## #2 — Weekly projections (`projections.py`)
Transparent projection, **no scraping / no API key**:
```
projected = base_ppg(position rank) × matchup × Vegas game environment × usage × injury
```
- floor/ceiling, confidence, and a full `breakdown` for every number.
- Tools: `project_player`, `project_players`.
- **The lineup optimizer now auto-fills projected points** (new
  `LineupOptimizer.auto_project`, default on) → `get_start_sit_recommendation`
  and `analyze_full_lineup` work without manual point entry.

## #1 — FAAB bid recommender (`faab_tools.py`)
`recommend_faab_bid(league_id, player, my_roster_id)` → a data-driven bid:
- **% of FAAB budget** (+ absolute when budget known), a tier, and safe/aggressive range.
- Inputs: real market value, **marginal upgrade for your roster** (value over your
  replacement at that position), **league demand** (trending adds), and **remaining
  budget / weeks left**. Transparent `breakdown` + reasoning + warnings.
- Handles non-FAAB leagues and deep-bench/unknown players gracefully.

## Tests
- New offline/mocked tests for the projection engine, optimizer auto-projection,
  and the FAAB recommender. Fixed a global-singleton test-isolation issue.
- Full suite green: **777 passing** on Python 3.11 & 3.12.

🤖 Erstellt mit Claude Code