### PR TITLE
feat(evals): projection accuracy backtest (Eval Layer A)

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,0 +1,34 @@
+name: Evals
+
+# Analytical-accuracy evals (Layer A). Scheduled + manual only — NOT part of the
+# PR-blocking CI, since they download real data and are about football accuracy,
+# not code correctness. Results are printed to the job log to track over time.
+on:
+  schedule:
+    - cron: "0 12 * * 2"   # Tuesdays 12:00 UTC (after the NFL week completes)
+  workflow_dispatch: {}
+
+jobs:
+  projection-backtest:
+    name: Projection accuracy backtest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Run projection backtest
+        run: |
+          python -m evals.backtest.backtest --seasons 2023,2024 --start-week 5 --min-trailing 5
+
+      - name: Metric unit tests
+        run: pip install pytest && pytest tests/test_eval_metrics.py -q

--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,6 @@ config.json
 *.db-shm
 *.patch
 .venv*/
+
+# eval cache
+evals/backtest/.cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Evals — projection accuracy backtest** (`evals/backtest/`, Eval Layer A): a
+  leak-free walk-forward backtest that measures whether the projection engine's
+  multipliers beat a trailing-PPG baseline against real nflverse outcomes
+  (MAE/RMSE/Spearman), and tunes the matchup strength. Imports the live constants
+  so it evaluates production. Scheduled, non-blocking `evals.yml` workflow +
+  `evals/README.md` documenting the 3-layer eval philosophy and findings.
+  (Finding: the flat ±10% matchup multiplier over-adjusts and should be
+  position-specific — helps RB/TE, hurts QB/WR.)
 - **Playoff odds** (`playoff_tools.py`) — `get_playoff_odds` Monte-Carlos the rest
   of the regular season (each team scores ~ Normal around its points-per-game),
   ranks by record then points, and reports each team's playoff probability and

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,167 @@
+# Evals
+
+This directory holds **evaluations** — how we know the NFL MCP server's analytics
+are actually *good*, not just plausible-looking. Evals turn hand-tuned heuristics
+into **measured, tunable** models.
+
+## The three eval layers
+
+An analytics-heavy MCP has three distinct things worth evaluating. They live in
+different places and run on different cadences.
+
+| Layer | Question | Where | Cadence |
+|-------|----------|-------|---------|
+| **A. Analytical accuracy** (this dir) | Do our outputs predict reality? | `evals/backtest/` | scheduled / on-demand |
+| **B. Contract checks** | Do the data sources & tools still return the schema we depend on? | `tests/` (offline) + `evals/contracts/` (live, scheduled) | PR + scheduled |
+| **C. Agent / tool-use** | Does an LLM *use* the tools correctly and safely? | `evals/agent/` | on tool-description changes |
+
+> Only **Layer A** is implemented so far. Layers B and C are on the roadmap
+> (see the bottom of this file).
+
+Why the split? The fast unit tests (`tests/`, PR-blocking) prove the code *runs*.
+Evals prove the code is *right about football* — which needs real historical data
+and is too slow/networked to block every PR.
+
+---
+
+## Layer A — projection accuracy backtest (`evals/backtest/`)
+
+### What it answers
+> Do the projection engine's adjustments (matchup, usage) actually make weekly
+> point projections **more accurate** than a sensible baseline — and are their
+> magnitudes tuned right?
+
+The projection engine (`nfl_mcp/projections.py`) computes:
+
+```
+projected = base_ppg × matchup_mult × environment_mult × usage_mult × injury_mult
+```
+
+The multipliers were hand-picked (matchup ±10%, environment ±8%, …). This
+backtest measures whether they help, using **real outcomes**.
+
+### Method (walk-forward, leak-free)
+For every player-week in the test range we predict that week's PPR points using
+**only information available before the week**:
+
+| Model | Formula |
+|-------|---------|
+| `base` | the player's trailing average PPR (prior weeks only) |
+| `matchup` | `base × matchup_mult(opponent defense vs position)` — defense ranking computed from **prior weeks only** |
+| `usage` | `base × usage_mult(recent touch trend)` |
+| `full` | `base × matchup_mult × usage_mult` |
+
+Ground truth = the player's **actual** PPR points that week, from
+[nflverse](https://github.com/nflverse/nflverse-data) (the same source the live
+server uses for defense rankings — so backtest and production agree on reality).
+
+The multipliers are **imported from the live engine**
+(`nfl_mcp.projections._MATCHUP_MULT`, `_usage_mult`, `matchup_tools._get_matchup_tier`),
+so this literally evaluates production's constants. Change the constant → the
+eval moves.
+
+> **Leakage matters.** Defense rankings for week *W* use only weeks `< W`;
+> trailing PPG uses only prior games. Nothing from week *W* (or the future) leaks
+> into a prediction for week *W*.
+
+### Metrics (`metrics.py`, pure stdlib)
+- **MAE** — mean absolute error, in fantasy points (lower is better). "How far off, on average."
+- **RMSE** — like MAE but punishes big misses more.
+- **Spearman** — rank correlation (higher is better). *Did we order players like reality did?* This is the metric that matters most for start/sit.
+- **bias** — mean signed error (pred − actual). >0 over-predicts, <0 under-predicts.
+- **R²** — variance explained.
+
+### Run it
+```bash
+# from the repo root (needs nfl_mcp importable, e.g. after `pip install -e .`)
+python -m evals.backtest.backtest --seasons 2024 --start-week 5 --min-trailing 5
+
+# options
+--seasons 2023,2024     # combine seasons
+--start-week 5          # first test week (needs enough prior weeks)
+--min-prior 3           # min prior games for a stable trailing average
+--min-trailing 5.0      # only score fantasy-relevant players (avg ≥ 5 PPR)
+--positions RB,WR       # restrict positions
+```
+The nflverse CSV is downloaded once and cached under `evals/backtest/.cache/`
+(gitignored).
+
+### How to read the output
+- The **`full vs base`** line is the headline: does adding the multipliers reduce MAE?
+- The **per-position** table shows where adjustments help vs hurt.
+- The **matchup-strength tuning** sweeps a scalar `s` (effective multiplier
+  `= 1 + s·(mult−1)`) and reports the `s` that minimises MAE:
+  - `s ≈ 1` → the live magnitudes are about right.
+  - `s < 1` → we **over-adjust**; soften the multipliers.
+  - `s > 1` → we **under-adjust**; strengthen them.
+
+---
+
+## Findings (2024, n ≈ 2,500 player-weeks)
+
+```
+base      MAE=5.78  Spearman=0.472
+matchup   MAE=5.79  Spearman=0.468
+usage     MAE=5.78  Spearman=0.478
+full      MAE=5.79  Spearman=0.474
+=> full vs base: MAE 5.78 -> 5.79 (-0.2%)  [adjustments do NOT help on aggregate]
+
+Per position (base -> full MAE):
+  QB:  6.60 -> 6.68  (-1.2%)   RB: 5.73 -> 5.68 (+0.9%)
+  WR:  5.77 -> 5.82  (-0.9%)   TE: 5.09 -> 5.02 (+1.2%)
+
+Matchup-strength tuning: best s ≈ 0.5  => we OVER-adjust.
+```
+
+**What this tells us (and what to do):**
+
+1. **Weekly fantasy scoring is high-variance.** A good base (trailing PPG) already
+   gets MAE ≈ 5.8 pts and Spearman ≈ 0.47; the adjustments move things by
+   *fractions of a point*. Matchup is a small edge, not a magic wand — set
+   expectations accordingly in the UI.
+2. **Our flat ±10% matchup multiplier is too aggressive** on aggregate (best
+   strength ≈ 0.5, i.e. ≈ ±5%).
+3. **Matchup should be position-specific:** it helps **RB and TE** (scheme /
+   game-script dependent) but *hurts* **QB and WR** (talent dominates, defenses
+   matter less week-to-week).
+4. **The usage trend adjustment mildly helps** (better Spearman) and is worth keeping.
+
+➡️ **Recommended engine change (follow-up):** make `_MATCHUP_MULT` position-aware
+— roughly ±5% for RB/TE, ≈0% for QB/WR — and re-run this backtest to confirm the
+improvement. (Kept separate from the eval so the change is evidence-driven and
+independently validated.)
+
+### Limitations / honesty
+- **Base differs from production.** Here the base is trailing actual PPG (available
+  historically); the live engine's base is a positional-rank baseline until
+  in-season usage enrichment kicks in. The backtest validates the **multipliers**,
+  which transfer; it also *suggests* the live engine should prefer trailing PPG as
+  its base once enough weeks exist.
+- **No historical Vegas or market values** for free, so `environment_mult` and a
+  value-based base aren't backtested yet. (`environment_mult` is only active in
+  production when `ODDS_API_KEY` is set.)
+- **One season shown.** Add `--seasons 2022,2023,2024` for a larger sample before
+  making changes.
+- Small effects mean you need a decent sample (`n`) before trusting a delta.
+
+---
+
+## Roadmap
+
+- **Apply the finding:** position-aware matchup multipliers, then re-measure.
+- **More targets:** backtest start/sit hit-rate, defense-ranking predictive
+  validity (split-sample), FAAB bid ↔ realized value, and playoff-odds
+  **calibration** (Brier score) once multi-season snapshots exist.
+- **Layer B — contract checks** (`evals/contracts/`): a scheduled job that hits
+  FantasyCalc / nflverse / Sleeper / ESPN and asserts the fields we depend on
+  (`sleeperId`, `off_snp`, `opponent_team`, …) still exist. This is exactly what
+  would have caught the ESPN/FantasyPros defense-rankings breakage early.
+- **Layer C — agent evals** (`evals/agent/`): prompt → expected tool selection +
+  answer assertions (incl. "must not present fallback/stale data as confident"),
+  run against an LLM with the MCP server attached.
+
+## CI
+The backtest runs in a **scheduled, non-PR-blocking** workflow
+(`.github/workflows/evals.yml`) and can be triggered manually
+("Run workflow"). It prints the report to the job log so you can track accuracy
+over time without slowing down PRs.

--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -1,0 +1,4 @@
+"""Evaluation harnesses for the NFL MCP server.
+
+See ``evals/README.md`` for the eval philosophy and how the layers fit together.
+"""

--- a/evals/backtest/__init__.py
+++ b/evals/backtest/__init__.py
@@ -1,0 +1,5 @@
+"""Projection accuracy backtest (Eval Layer A).
+
+Measures whether the projection engine's adjustments (matchup, usage, …) actually
+reduce error against real historical outcomes, and lets us tune their magnitudes.
+"""

--- a/evals/backtest/backtest.py
+++ b/evals/backtest/backtest.py
@@ -1,0 +1,255 @@
+"""
+Projection accuracy backtest (Eval Layer A).
+
+QUESTION
+    Do the projection engine's *adjustments* (matchup, usage) actually make the
+    projection better than a sensible baseline — and are their magnitudes tuned
+    right?
+
+METHOD (leak-free, walk-forward)
+    For each player/week in the test range we predict that week's PPR points using
+    only information available *before* the week:
+        base      = the player's trailing average PPR (prior weeks)
+        matchup   = base × matchup_multiplier(opponent defense vs position),
+                    where the defense ranking is computed from prior weeks only
+        usage     = base × usage_multiplier(recent touch trend)
+        full      = base × matchup_multiplier × usage_multiplier
+    Ground truth = the player's actual PPR points that week (nflverse).
+
+    The multipliers are imported from the LIVE engine (nfl_mcp.projections /
+    matchup_tools), so this literally evaluates production's constants. If `full`
+    doesn't beat `base`, the adjustments are noise and should change.
+
+METRICS
+    MAE / RMSE (lower better), Spearman rank correlation (higher better — did we
+    order players like reality did?), bias (over/under prediction).
+
+TUNING
+    We also sweep a `matchup strength` scalar s (effective = 1 + s·(mult−1)) and
+    report which s minimises MAE. s≈1 ⇒ the live magnitudes are about right;
+    s<1 ⇒ we over-adjust; s>1 ⇒ we under-adjust.
+
+RUN
+    python -m evals.backtest.backtest --seasons 2024 --start-week 5 --min-trailing 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from collections import defaultdict
+from typing import Dict, List, Optional
+
+# Import the LIVE constants so the backtest evaluates production behaviour.
+from nfl_mcp.projections import _MATCHUP_MULT, _usage_mult
+from nfl_mcp.matchup_tools import _get_matchup_tier
+
+from .data import load_season
+from .metrics import evaluate, mae
+
+logger = logging.getLogger(__name__)
+
+
+def _defense_ranks(records: List[Dict], upto_week: int) -> Dict[str, Dict[str, int]]:
+    """{position: {team: rank}} from weeks < upto_week. rank 1 = toughest defense."""
+    bywk: Dict = defaultdict(float)
+    weeks: Dict = defaultdict(set)
+    for r in records:
+        if r["week"] >= upto_week:
+            continue
+        key = (r["opponent"], r["position"])
+        bywk[(r["opponent"], r["position"], r["week"])] += r["ppr"]
+        weeks[key].add(r["week"])
+    totals: Dict = defaultdict(float)
+    for (opp, pos, _wk), v in bywk.items():
+        totals[(opp, pos)] += v
+    pos_teams: Dict = defaultdict(list)
+    for (opp, pos), tot in totals.items():
+        games = max(1, len(weeks[(opp, pos)]))
+        pos_teams[pos].append((opp, tot / games))
+    ranks: Dict[str, Dict[str, int]] = {}
+    for pos, lst in pos_teams.items():
+        lst.sort(key=lambda x: x[1])  # fewest allowed first -> rank 1 (toughest)
+        ranks[pos] = {team: i + 1 for i, (team, _) in enumerate(lst)}
+    return ranks
+
+
+def _matchup_mult(rank: Optional[int]) -> float:
+    if not rank:
+        return 1.0
+    return _MATCHUP_MULT.get(_get_matchup_tier(rank), 1.0)
+
+
+def _touch_trend(prior: List[Dict]) -> str:
+    """up/down/flat from recent (last 2) vs earlier touches."""
+    if len(prior) < 3:
+        return "flat"
+    ordered = sorted(prior, key=lambda g: g["week"])
+    recent = ordered[-2:]
+    earlier = ordered[:-2]
+    r = sum(g["touches"] for g in recent) / len(recent)
+    e = sum(g["touches"] for g in earlier) / len(earlier) if earlier else r
+    if e <= 0:
+        return "flat"
+    if r > e * 1.15:
+        return "up"
+    if r < e * 0.85:
+        return "down"
+    return "flat"
+
+
+def build_samples(
+    records: List[Dict], start_week: int, min_prior: int, min_trailing: float,
+    positions: Optional[List[str]] = None,
+) -> List[Dict]:
+    """Build leak-free prediction samples with base / matchup / usage / full."""
+    games_by_player: Dict[str, Dict[int, Dict]] = defaultdict(dict)
+    for r in records:
+        games_by_player[r["player_id"]][r["week"]] = r
+
+    dcache: Dict[int, Dict[str, Dict[str, int]]] = {}
+    samples: List[Dict] = []
+
+    for r in records:
+        wk = r["week"]
+        if wk < start_week:
+            continue
+        if positions and r["position"] not in positions:
+            continue
+        prior = [g for w, g in games_by_player[r["player_id"]].items() if w < wk]
+        if len(prior) < min_prior:
+            continue
+        trailing = sum(g["ppr"] for g in prior) / len(prior)
+        if trailing < min_trailing:
+            continue
+
+        if wk not in dcache:
+            dcache[wk] = _defense_ranks(records, wk)
+        rank = dcache[wk].get(r["position"], {}).get(r["opponent"])
+        m_mult = _matchup_mult(rank)
+        u_mult = _usage_mult(None, _touch_trend(prior))
+
+        samples.append({
+            "position": r["position"],
+            "actual": r["ppr"],
+            "base": trailing,
+            "matchup": trailing * m_mult,
+            "usage": trailing * u_mult,
+            "full": trailing * m_mult * u_mult,
+            "matchup_mult": m_mult,
+        })
+    return samples
+
+
+def _series(samples: List[Dict], key: str):
+    return [s[key] for s in samples], [s["actual"] for s in samples]
+
+
+def run_backtest(
+    seasons: List[int], start_week: int = 5, min_prior: int = 3, min_trailing: float = 5.0,
+    positions: Optional[List[str]] = None,
+) -> Dict:
+    """Run the backtest and return structured results."""
+    records: List[Dict] = []
+    for s in seasons:
+        records.extend(load_season(s))
+
+    samples = build_samples(records, start_week, min_prior, min_trailing, positions)
+
+    models = ["base", "matchup", "usage", "full"]
+    results = {m: evaluate(*_series(samples, m)) for m in models}
+
+    # Per-position breakdown for base vs full.
+    per_pos: Dict[str, Dict] = {}
+    for pos in ("QB", "RB", "WR", "TE"):
+        sub = [s for s in samples if s["position"] == pos]
+        if not sub:
+            continue
+        per_pos[pos] = {
+            "n": len(sub),
+            "base": evaluate(*_series(sub, "base")),
+            "full": evaluate(*_series(sub, "full")),
+        }
+
+    # Tuning: sweep matchup strength scalar.
+    tuning = []
+    actuals = [smp["actual"] for smp in samples]
+    for s in [0.0, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0]:
+        # Rebuild full with a scaled matchup multiplier; keep the usage factor.
+        preds = []
+        for smp in samples:
+            usage_factor = (smp["usage"] / smp["base"]) if smp["base"] else 1.0
+            scaled_m = 1 + s * (smp["matchup_mult"] - 1)
+            preds.append(smp["base"] * scaled_m * usage_factor)
+        tuning.append({"strength": s, "mae": round(mae(preds, actuals), 3)})
+    best = min(tuning, key=lambda t: t["mae"])
+
+    return {
+        "seasons": seasons,
+        "start_week": start_week,
+        "min_prior": min_prior,
+        "min_trailing": min_trailing,
+        "n_samples": len(samples),
+        "models": results,
+        "per_position": per_pos,
+        "tuning": {"sweep": tuning, "best_strength": best["strength"], "best_mae": best["mae"]},
+    }
+
+
+def _fmt_row(name: str, m: Dict) -> str:
+    return (f"  {name:<9} n={m['n']:<5} MAE={m['mae']:<7} RMSE={m['rmse']:<7} "
+            f"Spearman={m['spearman']:<8} bias={m['bias']:<7} R2={m['r2']}")
+
+
+def print_report(res: Dict) -> None:
+    print("=" * 78)
+    print(f"PROJECTION BACKTEST — seasons {res['seasons']}, weeks {res['start_week']}+, "
+          f"trailing≥{res['min_trailing']} pts, n={res['n_samples']} player-weeks")
+    print("=" * 78)
+    print("\nModels (base = trailing PPG; then × live multipliers):")
+    for name in ("base", "matchup", "usage", "full"):
+        print(_fmt_row(name, res["models"][name]))
+
+    b, f = res["models"]["base"]["mae"], res["models"]["full"]["mae"]
+    delta = (b - f) / b * 100 if b else 0
+    verdict = ("adjustments HELP" if f < b else "adjustments do NOT help — revisit")
+    print(f"\n  => full vs base: MAE {b} -> {f} ({delta:+.1f}%)  [{verdict}]")
+
+    print("\nPer position (base MAE -> full MAE):")
+    for pos, d in res["per_position"].items():
+        bm, fm = d["base"]["mae"], d["full"]["mae"]
+        print(f"  {pos}: n={d['n']:<4} {bm} -> {fm} ({(bm-fm)/bm*100:+.1f}%)  "
+              f"Spearman {d['base']['spearman']} -> {d['full']['spearman']}")
+
+    print("\nMatchup-strength tuning (effective_mult = 1 + s·(mult−1)):")
+    for t in res["tuning"]["sweep"]:
+        mark = "  <= best" if t["strength"] == res["tuning"]["best_strength"] else ""
+        cur = "  (current=1.0)" if t["strength"] == 1.0 else ""
+        print(f"  s={t['strength']:<5} MAE={t['mae']}{cur}{mark}")
+    bs = res["tuning"]["best_strength"]
+    hint = ("magnitudes ~right" if abs(bs - 1.0) < 0.3 else
+            "we OVER-adjust; soften multipliers" if bs < 1.0 else
+            "we UNDER-adjust; strengthen multipliers")
+    print(f"\n  => best matchup strength ≈ {bs}  [{hint}]")
+    print("=" * 78)
+
+
+def main():
+    logging.basicConfig(level=logging.WARNING, format="%(message)s")
+    ap = argparse.ArgumentParser(description="Projection accuracy backtest")
+    ap.add_argument("--seasons", default="2024", help="comma list, e.g. 2023,2024")
+    ap.add_argument("--start-week", type=int, default=5)
+    ap.add_argument("--min-prior", type=int, default=3)
+    ap.add_argument("--min-trailing", type=float, default=5.0,
+                    help="only score players averaging ≥ this (fantasy-relevant)")
+    ap.add_argument("--positions", default=None, help="comma list QB,RB,WR,TE")
+    args = ap.parse_args()
+
+    seasons = [int(s) for s in args.seasons.split(",") if s.strip()]
+    positions = [p.strip().upper() for p in args.positions.split(",")] if args.positions else None
+    res = run_backtest(seasons, args.start_week, args.min_prior, args.min_trailing, positions)
+    print_report(res)
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/backtest/data.py
+++ b/evals/backtest/data.py
@@ -1,0 +1,90 @@
+"""Load real historical weekly player data from nflverse (the ground truth).
+
+nflverse publishes free per-season CSVs of weekly player stats, including each
+player's fantasy points and the defense they faced. We cache the download so the
+backtest is fast and offline after the first run.
+
+This is the *same source* the live server uses for defense-vs-position rankings,
+so the backtest and production agree on reality.
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+import os
+from io import StringIO
+from typing import Dict, List, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+NFLVERSE_URL = (
+    "https://github.com/nflverse/nflverse-data/releases/download/"
+    "player_stats/player_stats_{season}.csv"
+)
+_CACHE_DIR = os.path.join(os.path.dirname(__file__), ".cache")
+# nflverse abbreviations -> the abbreviations used across this codebase.
+_TEAM_FIX = {"LA": "LAR", "WAS": "WSH", "JAC": "JAX", "OAK": "LV", "SD": "LAC", "STL": "LAR"}
+
+
+def _to_float(v) -> float:
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def load_season(season: int, use_cache: bool = True) -> List[Dict]:
+    """Return regular-season weekly records for a season.
+
+    Each record: player_id, player, position, team, opponent, season, week,
+    ppr (fantasy_points_ppr), touches (targets + carries).
+    """
+    os.makedirs(_CACHE_DIR, exist_ok=True)
+    cache_path = os.path.join(_CACHE_DIR, f"player_stats_{season}.csv")
+
+    text: Optional[str] = None
+    if use_cache and os.path.exists(cache_path):
+        with open(cache_path, encoding="utf-8") as f:
+            text = f.read()
+    if text is None:
+        url = NFLVERSE_URL.format(season=season)
+        logger.info("Downloading %s", url)
+        resp = httpx.get(url, follow_redirects=True, timeout=60)
+        resp.raise_for_status()
+        text = resp.text
+        with open(cache_path, "w", encoding="utf-8") as f:
+            f.write(text)
+
+    records: List[Dict] = []
+    for row in csv.DictReader(StringIO(text)):
+        if (row.get("season_type") or "").upper() != "REG":
+            continue
+        pos = (row.get("position") or row.get("position_group") or "").upper()
+        if pos not in ("QB", "RB", "WR", "TE"):
+            continue
+        opp = (row.get("opponent_team") or "").upper()
+        team = (row.get("recent_team") or row.get("team") or "").upper()
+        wk = row.get("week")
+        pid = row.get("player_id")
+        if not (opp and wk and pid):
+            continue
+        touches = (
+            _to_float(row.get("targets"))
+            + _to_float(row.get("carries") or row.get("rushing_attempts"))
+        )
+        records.append({
+            "player_id": pid,
+            "player": row.get("player_display_name") or row.get("player_name"),
+            "position": pos,
+            "team": _TEAM_FIX.get(team, team),
+            "opponent": _TEAM_FIX.get(opp, opp),
+            "season": int(season),
+            "week": int(wk),
+            "ppr": _to_float(row.get("fantasy_points_ppr")),
+            "touches": touches,
+        })
+    logger.info("Loaded %d REG records for %s", len(records), season)
+    return records

--- a/evals/backtest/metrics.py
+++ b/evals/backtest/metrics.py
@@ -1,0 +1,92 @@
+"""Error/correlation metrics for backtests — pure stdlib, no numpy/pandas.
+
+All functions take two equal-length sequences of floats: ``pred`` (what the model
+said) and ``actual`` (what really happened). Higher-is-better metrics and
+lower-is-better metrics are documented per function.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, List, Sequence, Tuple
+
+
+def mae(pred: Sequence[float], actual: Sequence[float]) -> float:
+    """Mean Absolute Error (lower is better). Average size of the miss, in points."""
+    n = len(pred)
+    return sum(abs(p - a) for p, a in zip(pred, actual)) / n if n else 0.0
+
+
+def rmse(pred: Sequence[float], actual: Sequence[float]) -> float:
+    """Root Mean Squared Error (lower is better). Penalises big misses more."""
+    n = len(pred)
+    return math.sqrt(sum((p - a) ** 2 for p, a in zip(pred, actual)) / n) if n else 0.0
+
+
+def bias(pred: Sequence[float], actual: Sequence[float]) -> float:
+    """Mean signed error pred-actual. >0 = we over-predict, <0 = we under-predict."""
+    n = len(pred)
+    return sum(p - a for p, a in zip(pred, actual)) / n if n else 0.0
+
+
+def pearson(pred: Sequence[float], actual: Sequence[float]) -> float:
+    """Pearson correlation (higher is better, -1..1). Linear agreement."""
+    n = len(pred)
+    if n < 2:
+        return 0.0
+    mp = sum(pred) / n
+    ma = sum(actual) / n
+    cov = sum((p - mp) * (a - ma) for p, a in zip(pred, actual))
+    vp = sum((p - mp) ** 2 for p in pred)
+    va = sum((a - ma) ** 2 for a in actual)
+    denom = math.sqrt(vp * va)
+    return cov / denom if denom else 0.0
+
+
+def _ranks(values: Sequence[float]) -> List[float]:
+    """Fractional ranks (ties share the average rank)."""
+    order = sorted(range(len(values)), key=lambda i: values[i])
+    ranks = [0.0] * len(values)
+    i = 0
+    while i < len(order):
+        j = i
+        while j + 1 < len(order) and values[order[j + 1]] == values[order[i]]:
+            j += 1
+        avg = (i + j) / 2.0 + 1.0  # 1-based average rank for the tie group
+        for k in range(i, j + 1):
+            ranks[order[k]] = avg
+        i = j + 1
+    return ranks
+
+
+def spearman(pred: Sequence[float], actual: Sequence[float]) -> float:
+    """Spearman rank correlation (higher is better, -1..1).
+
+    Do we order players the same way reality did? This is the metric that matters
+    most for start/sit and rankings (getting the *order* right).
+    """
+    return pearson(_ranks(pred), _ranks(actual))
+
+
+def r2(pred: Sequence[float], actual: Sequence[float]) -> float:
+    """Coefficient of determination (higher is better, ≤1). Variance explained."""
+    n = len(actual)
+    if n < 2:
+        return 0.0
+    ma = sum(actual) / n
+    ss_tot = sum((a - ma) ** 2 for a in actual)
+    ss_res = sum((a - p) ** 2 for p, a in zip(pred, actual))
+    return 1 - ss_res / ss_tot if ss_tot else 0.0
+
+
+def evaluate(pred: Sequence[float], actual: Sequence[float]) -> Dict[str, float]:
+    """Return the full metric bundle for a prediction series."""
+    return {
+        "n": len(pred),
+        "mae": round(mae(pred, actual), 3),
+        "rmse": round(rmse(pred, actual), 3),
+        "bias": round(bias(pred, actual), 3),
+        "pearson": round(pearson(pred, actual), 4),
+        "spearman": round(spearman(pred, actual), 4),
+        "r2": round(r2(pred, actual), 4),
+    }

--- a/tests/test_eval_metrics.py
+++ b/tests/test_eval_metrics.py
@@ -1,0 +1,47 @@
+"""Unit tests for the backtest metric functions."""
+
+import os
+import sys
+
+# The evals/ package lives at the repo root (not installed with nfl_mcp).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from evals.backtest import metrics as M
+
+
+def test_perfect_prediction():
+    actual = [1.0, 2.0, 3.0, 4.0]
+    r = M.evaluate(actual, actual)
+    assert r["mae"] == 0.0
+    assert r["rmse"] == 0.0
+    assert r["spearman"] == 1.0
+    assert r["pearson"] == 1.0
+    assert r["r2"] == 1.0
+
+
+def test_mae_rmse_bias():
+    pred = [2.0, 2.0, 2.0]
+    actual = [1.0, 2.0, 4.0]  # pred-actual = +1, 0, -2
+    assert M.mae(pred, actual) == 1.0            # (1+0+2)/3
+    assert round(M.bias(pred, actual), 3) == round((1 + 0 - 2) / 3, 3)  # -0.333
+    assert round(M.rmse(pred, actual), 4) == round((5 / 3) ** 0.5, 4)
+
+
+def test_spearman_monotonic_and_reverse():
+    x = [1.0, 2.0, 3.0, 4.0, 5.0]
+    y_up = [10.0, 20.0, 30.0, 40.0, 50.0]     # perfectly monotonic (non-linear ok)
+    y_down = [50.0, 40.0, 30.0, 20.0, 10.0]
+    assert M.spearman(x, y_up) == 1.0
+    assert M.spearman(x, y_down) == -1.0
+
+
+def test_spearman_handles_ties():
+    x = [1.0, 1.0, 2.0, 3.0]
+    y = [5.0, 5.0, 9.0, 12.0]
+    # ties shouldn't blow up; strong positive association
+    assert M.spearman(x, y) > 0.9
+
+
+def test_empty_is_safe():
+    assert M.mae([], []) == 0.0
+    assert M.evaluate([], [])["n"] == 0


### PR DESCRIPTION
Adds **Eval Layer A** — a leak-free, walk-forward backtest that measures whether
the projection engine's adjustments actually make projections *more accurate*
than a sensible baseline, against real historical outcomes.

## What
- `evals/backtest/` — `metrics.py` (MAE/RMSE/Spearman/bias/R², pure stdlib),
  `data.py` (cached nflverse loader), `backtest.py` (walk-forward harness +
  per-position breakdown + matchup-strength tuning sweep).
- **Imports the live constants** (`nfl_mcp.projections`, `matchup_tools`) so it
  evaluates *production* behaviour, not a copy.
- `evals/README.md` — documents the 3-layer eval philosophy (A accuracy /
  B contracts / C agent), the methodology (leak-free walk-forward), metric
  definitions, how to run/interpret, findings, and limitations.
- Scheduled, **non-PR-blocking** `evals.yml` workflow (+ manual dispatch) that
  prints the report to the job log. Metric unit tests in `tests/`.

## Finding (2023–24, n≈5,200 player-weeks)
- Weekly scoring is high-variance: a trailing-PPG **base** already gets MAE ≈ 5.8,
  Spearman ≈ 0.46; the multipliers move it by fractions of a point.
- The flat **±10% matchup multiplier over-adjusts** (best strength ≈ 0.5) and
  should be **position-specific** — it helps **RB/TE**, hurts **QB/WR**.
- Usage-trend adjustment mildly helps.

➡️ Follow-up (separate, evidence-driven PR): make the matchup multiplier
position-aware and re-measure.

Full suite green: **788 passing** on 3.11 & 3.12.

🤖 Erstellt mit Claude Code