### PR TITLE
feat(evals): live source contract checks (Eval Layer B)

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,0 +1,31 @@
+name: Source Contracts
+
+# Layer B — live data-source contract checks. Runs DAILY (breakage should be
+# caught fast) and on demand. NOT part of PR CI (it's live/networked). The job
+# goes red — and GitHub notifies — if a CRITICAL upstream contract breaks
+# (e.g. FantasyCalc drops sleeperId, or the nflverse/Sleeper shape changes).
+on:
+  schedule:
+    - cron: "0 13 * * *"   # daily 13:00 UTC
+  workflow_dispatch: {}
+
+jobs:
+  contracts:
+    name: Data-source contract checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Run contract checks (fails on critical breakage)
+        run: python -m evals.contracts.checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Evals — data-source contract checks** (`evals/contracts/`, Eval Layer B): a
+  daily, non-blocking `contracts.yml` workflow that hits FantasyCalc / nflverse /
+  Sleeper / ESPN and asserts the fields we depend on (`sleeperId`, `off_snp`,
+  `opponent_team`, …) still exist — the early-warning system that would have
+  caught the ESPN/FantasyPros defense-rankings breakage immediately. Critical
+  failures fail the job; offline runner tests included.
+
 ### Changed
 - **Matchup multiplier is now position-specific** (`matchup_multiplier()` in
   projections), tuned by the backtest: RB full weight, TE half, QB a quarter,

--- a/evals/README.md
+++ b/evals/README.md
@@ -11,12 +11,11 @@ different places and run on different cadences.
 
 | Layer | Question | Where | Cadence |
 |-------|----------|-------|---------|
-| **A. Analytical accuracy** (this dir) | Do our outputs predict reality? | `evals/backtest/` | scheduled / on-demand |
+| **A. Analytical accuracy** | Do our outputs predict reality? | `evals/backtest/` | scheduled / on-demand |
 | **B. Contract checks** | Do the data sources & tools still return the schema we depend on? | `tests/` (offline) + `evals/contracts/` (live, scheduled) | PR + scheduled |
 | **C. Agent / tool-use** | Does an LLM *use* the tools correctly and safely? | `evals/agent/` | on tool-description changes |
 
-> Only **Layer A** is implemented so far. Layers B and C are on the roadmap
-> (see the bottom of this file).
+> **Layers A and B are implemented.** Layer C is on the roadmap (see the bottom).
 
 Why the split? The fast unit tests (`tests/`, PR-blocking) prove the code *runs*.
 Evals prove the code is *right about football* — which needs real historical data
@@ -168,16 +167,50 @@ Layer A is for.
 
 ---
 
+---
+
+## Layer B — data-source contract checks (`evals/contracts/`)
+
+An **early-warning system.** Every day, hit each upstream source and assert the
+fields our code depends on still exist. This is exactly what would have caught the
+ESPN/FantasyPros defense-rankings breakage the day it happened, instead of it
+silently degrading to placeholder data.
+
+Where possible a check drives our *own* code (so it also catches our parsing
+breaking); the field-level checks hit the raw API so a failure pinpoints an
+*upstream* change.
+
+| Check | Level | Asserts |
+|-------|-------|---------|
+| `fantasycalc.values` | critical | list of values; `player.sleeperId`, `position`, `value`, `positionRank`; and our value service returns them |
+| `nflverse.defense_rankings` | critical | 32 teams × QB/RB/WR/TE, computed via our analyzer, `source == nflverse` |
+| `nflverse.usage_columns` | critical | player_stats CSV parses with `fantasy_points_ppr` + targets/carries |
+| `sleeper.state` | critical | `week` / `season` / `season_type` |
+| `sleeper.week_stats` | critical | `off_snp` / `tm_off_snp` / `rec_tgt` present (snap%/usage enrichment) |
+| `sleeper.players` | warn | big players map; entries have `position` + name |
+| `espn.teams` | warn | ≥32 teams with `abbreviation` |
+| `espn.news` | warn | articles with headlines |
+
+Checks auto-fall-back to the most recent season that has published data, so they
+stay green year-round.
+
+```bash
+python -m evals.contracts.checks     # exits non-zero iff a CRITICAL check fails
+```
+
+Runs daily via `.github/workflows/contracts.yml` (+ manual dispatch). A **critical**
+failure turns the job red and GitHub notifies you; **warn** failures are reported
+but don't fail the job. Offline runner tests live in `tests/test_eval_contracts.py`.
+
+---
+
 ## Roadmap
 
 - ~~Apply the finding: position-aware matchup multipliers, then re-measure.~~ ✅ done.
-- **More targets:** backtest start/sit hit-rate, defense-ranking predictive
-  validity (split-sample), FAAB bid ↔ realized value, and playoff-odds
+- ~~Layer B — live source contract checks.~~ ✅ done (`evals/contracts/`).
+- **More Layer A targets:** backtest start/sit hit-rate, defense-ranking
+  predictive validity (split-sample), FAAB bid ↔ realized value, and playoff-odds
   **calibration** (Brier score) once multi-season snapshots exist.
-- **Layer B — contract checks** (`evals/contracts/`): a scheduled job that hits
-  FantasyCalc / nflverse / Sleeper / ESPN and asserts the fields we depend on
-  (`sleeperId`, `off_snp`, `opponent_team`, …) still exist. This is exactly what
-  would have caught the ESPN/FantasyPros defense-rankings breakage early.
 - **Layer C — agent evals** (`evals/agent/`): prompt → expected tool selection +
   answer assertions (incl. "must not present fallback/stale data as confident"),
   run against an LLM with the MCP server attached.

--- a/evals/contracts/__init__.py
+++ b/evals/contracts/__init__.py
@@ -1,0 +1,9 @@
+"""Live data-source contract checks (Eval Layer B).
+
+Early-warning system: hit each upstream data source and assert that the fields
+and shapes our code depends on still exist. This is exactly what would have
+caught the ESPN/FantasyPros defense-rankings breakage the day it happened.
+
+Run: ``python -m evals.contracts.checks`` (exits non-zero if a CRITICAL check
+fails). Runs on a schedule via ``.github/workflows/contracts.yml``.
+"""

--- a/evals/contracts/checks.py
+++ b/evals/contracts/checks.py
@@ -1,0 +1,210 @@
+"""
+Live data-source contract checks (Eval Layer B).
+
+Each check hits a real upstream source (or drives our own code that does) and
+asserts the fields we depend on still exist. A check "fails" by raising; the
+runner turns that into a red result. CRITICAL failures make the process exit
+non-zero so the scheduled workflow goes red and notifies.
+
+Design notes
+- Field-level checks hit the raw API so a failure pinpoints an *upstream* change.
+- A couple of checks drive our own code paths (FantasyCalc via the value service,
+  nflverse via the defense analyzer) so they also catch *our* parsing breaking.
+- Everything is best-effort and isolated: one source being down doesn't abort the
+  others.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import datetime, UTC
+from typing import Callable, List, Tuple
+
+import httpx
+
+# (name, critical, fn)
+CHECKS: List[Tuple[str, bool, Callable[[], str]]] = []
+
+
+def check(name: str, critical: bool = True):
+    def deco(fn: Callable[[], str]):
+        CHECKS.append((name, critical, fn))
+        return fn
+    return deco
+
+
+def _get(url: str, **kw) -> httpx.Response:
+    r = httpx.get(url, follow_redirects=True, timeout=45, **kw)
+    r.raise_for_status()
+    return r
+
+
+def _completed_seasons() -> List[int]:
+    """Recent seasons that should have full published data (newest first)."""
+    now = datetime.now(UTC)
+    base = now.year - (1 if now.month >= 3 else 2)
+    return [base, base - 1]
+
+
+# ---------------------------------------------------------------------------
+# FantasyCalc — powers player values, trades, draft board, projections base
+# ---------------------------------------------------------------------------
+@check("fantasycalc.values", critical=True)
+def _fantasycalc() -> str:
+    data = _get(
+        "https://api.fantasycalc.com/values/current",
+        params={"isDynasty": "false", "numQbs": 1, "numTeams": 12, "ppr": 1},
+    ).json()
+    assert isinstance(data, list) and len(data) > 100, f"expected a big list, got {type(data)} len={len(data) if hasattr(data,'__len__') else '?'}"
+    first = data[0]
+    player = first.get("player") or {}
+    assert player.get("sleeperId"), "player.sleeperId missing (breaks Sleeper mapping)"
+    assert player.get("position"), "player.position missing"
+    assert first.get("value") is not None, "value missing"
+    assert first.get("positionRank") is not None, "positionRank missing"
+    # end-to-end through our service (catches our parsing too)
+    from nfl_mcp.player_values import PlayerValuesService
+    svc = PlayerValuesService(db=None)
+    res = asyncio.run(svc.get_values(1.0, 1, 12, False))
+    assert res.get("source") == "fantasycalc" and res.get("count", 0) > 100, \
+        f"value service returned source={res.get('source')} count={res.get('count')}"
+    return f"{len(data)} values; top={player.get('name')} (sleeperId ok)"
+
+
+# ---------------------------------------------------------------------------
+# nflverse — powers defense-vs-position rankings + backtest ground truth
+# ---------------------------------------------------------------------------
+@check("nflverse.defense_rankings", critical=True)
+def _nflverse_defense() -> str:
+    from nfl_mcp.matchup_tools import DefenseRankingsAnalyzer
+    an = DefenseRankingsAnalyzer(db=None)
+    for season in _completed_seasons():
+        rankings = asyncio.run(an.fetch_defense_rankings(season))
+        wr = rankings.get("WR", [])
+        if wr and wr[0].get("source") == "nflverse":
+            assert len(wr) == 32, f"expected 32 teams, got {len(wr)}"
+            for pos in ("QB", "RB", "TE"):
+                assert len(rankings.get(pos, [])) == 32, f"{pos} not 32 teams"
+            return f"{season}: 32 teams × 4 positions from nflverse"
+    raise AssertionError(f"no nflverse defense data for seasons {_completed_seasons()}")
+
+
+@check("nflverse.usage_columns", critical=True)
+def _nflverse_columns() -> str:
+    from evals.backtest.data import load_season
+    for season in _completed_seasons():
+        try:
+            recs = load_season(season)
+        except Exception:
+            continue  # that season's CSV not published yet -> try older
+        if recs:
+            assert any(r["ppr"] for r in recs), "no fantasy_points_ppr values"
+            assert any(r["touches"] > 0 for r in recs), "no targets/carries (touches)"
+            return f"{season}: {len(recs)} REG records with ppr + touches"
+    raise AssertionError("nflverse player_stats unavailable for recent seasons")
+
+
+# ---------------------------------------------------------------------------
+# Sleeper — powers league/roster/matchups + usage & snap enrichment
+# ---------------------------------------------------------------------------
+@check("sleeper.state", critical=True)
+def _sleeper_state() -> str:
+    d = _get("https://api.sleeper.app/v1/state/nfl").json()
+    for k in ("week", "season", "season_type"):
+        assert k in d, f"state missing '{k}'"
+    return f"week={d['week']} season={d['season']} ({d['season_type']})"
+
+
+@check("sleeper.week_stats", critical=True)
+def _sleeper_week_stats() -> str:
+    """Snap% + targets enrichment depends on off_snp / tm_off_snp / rec_tgt."""
+    for season in _completed_seasons():
+        try:
+            d = _get(f"https://api.sleeper.app/v1/stats/nfl/regular/{season}/1").json()
+        except Exception:
+            continue
+        if not (isinstance(d, dict) and len(d) > 100):
+            continue
+        have_snaps = sum(1 for s in d.values() if isinstance(s, dict) and "off_snp" in s and "tm_off_snp" in s)
+        have_tgt = sum(1 for s in d.values() if isinstance(s, dict) and "rec_tgt" in s)
+        assert have_snaps > 50, f"only {have_snaps} players with off_snp/tm_off_snp"
+        assert have_tgt > 50, f"only {have_tgt} players with rec_tgt"
+        return f"{season} wk1: {have_snaps} w/ snaps, {have_tgt} w/ targets"
+    raise AssertionError("no sleeper week stats for recent seasons")
+
+
+@check("sleeper.players", critical=False)
+def _sleeper_players() -> str:
+    d = _get("https://api.sleeper.app/v1/players/nfl").json()
+    assert isinstance(d, dict) and len(d) > 1000, "players map too small"
+    sample = next((v for v in d.values() if isinstance(v, dict) and v.get("position")), None)
+    assert sample and (sample.get("full_name") or sample.get("last_name")), "player entry shape changed"
+    return f"{len(d)} players; sample has position + name"
+
+
+# ---------------------------------------------------------------------------
+# ESPN — powers news/teams/injuries/standings/schedules/coaching (warn-level)
+# ---------------------------------------------------------------------------
+@check("espn.teams", critical=False)
+def _espn_teams() -> str:
+    d = _get("https://site.api.espn.com/apis/site/v2/sports/football/nfl/teams").json()
+    teams = d.get("sports", [{}])[0].get("leagues", [{}])[0].get("teams", [])
+    assert len(teams) >= 32, f"expected ≥32 teams, got {len(teams)}"
+    t0 = teams[0].get("team", {})
+    assert t0.get("abbreviation"), "team.abbreviation missing"
+    return f"{len(teams)} teams; sample={t0.get('abbreviation')}"
+
+
+@check("espn.news", critical=False)
+def _espn_news() -> str:
+    d = _get("https://site.api.espn.com/apis/site/v2/sports/football/nfl/news").json()
+    arts = d.get("articles", [])
+    assert arts and arts[0].get("headline"), "news articles/headline missing"
+    return f"{len(arts)} articles"
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+def run_all() -> List[dict]:
+    results = []
+    for name, critical, fn in CHECKS:
+        try:
+            detail = fn()
+            results.append({"name": name, "critical": critical, "ok": True, "detail": detail})
+        except Exception as e:  # noqa: BLE001 - report any failure
+            results.append({"name": name, "critical": critical, "ok": False, "detail": f"{type(e).__name__}: {e}"})
+    return results
+
+
+def exit_code(results: List[dict]) -> int:
+    """Non-zero iff a CRITICAL check failed (warnings don't fail the job)."""
+    return 1 if any((not r["ok"] and r["critical"]) for r in results) else 0
+
+
+def main() -> int:
+    print("=" * 78)
+    print(f"DATA-SOURCE CONTRACT CHECKS — {datetime.now(UTC).isoformat(timespec='seconds')}")
+    print("=" * 78)
+    results = run_all()
+    crit_fail = 0
+    warn_fail = 0
+    for r in results:
+        icon = "✅" if r["ok"] else ("❌" if r["critical"] else "⚠️ ")
+        tag = "CRIT" if r["critical"] else "warn"
+        print(f"  {icon} [{tag}] {r['name']:<28} {r['detail']}")
+        if not r["ok"]:
+            if r["critical"]:
+                crit_fail += 1
+            else:
+                warn_fail += 1
+    print("-" * 78)
+    ok = sum(1 for r in results if r["ok"])
+    print(f"  {ok}/{len(results)} passed | {crit_fail} critical failure(s), {warn_fail} warning(s)")
+    print("=" * 78)
+    return exit_code(results)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_eval_contracts.py
+++ b/tests/test_eval_contracts.py
@@ -1,0 +1,60 @@
+"""Offline tests for the contract-check runner (no network).
+
+The checks themselves are live (Layer B, scheduled). Here we only verify the
+runner's isolation and exit-code semantics with fake checks.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from evals.contracts import checks as C
+
+
+def _fake(passing_critical=True, failing_warn=True):
+    reg = []
+
+    def ok():
+        return "fine"
+
+    def boom():
+        raise ValueError("upstream changed")
+
+    if passing_critical:
+        reg.append(("ok.crit", True, ok))
+    if failing_warn:
+        reg.append(("bad.warn", False, boom))
+    return reg
+
+
+def test_run_all_isolates_failures(monkeypatch):
+    monkeypatch.setattr(C, "CHECKS", _fake())
+    results = C.run_all()
+    by = {r["name"]: r for r in results}
+    assert by["ok.crit"]["ok"] is True
+    assert by["bad.warn"]["ok"] is False
+    assert "upstream changed" in by["bad.warn"]["detail"]
+
+
+def test_exit_code_warn_only_is_zero():
+    results = [
+        {"name": "a", "critical": True, "ok": True, "detail": ""},
+        {"name": "b", "critical": False, "ok": False, "detail": "x"},  # warn fail
+    ]
+    assert C.exit_code(results) == 0
+
+
+def test_exit_code_critical_fail_is_one():
+    results = [
+        {"name": "a", "critical": True, "ok": False, "detail": "x"},  # crit fail
+        {"name": "b", "critical": False, "ok": True, "detail": ""},
+    ]
+    assert C.exit_code(results) == 1
+
+
+def test_all_registered_checks_have_names():
+    # Sanity: the real registry is populated and well-formed.
+    assert len(C.CHECKS) >= 5
+    for name, critical, fn in C.CHECKS:
+        assert isinstance(name, str) and callable(fn) and isinstance(critical, bool)


### PR DESCRIPTION
Adds **Eval Layer B** — a daily early-warning system that hits each upstream data
source and asserts the fields our code depends on still exist. This is exactly
what would have caught the ESPN/FantasyPros defense-rankings breakage the day it
happened, instead of it silently degrading to placeholder data.

## What's checked (`evals/contracts/checks.py`)
| Check | Level | Asserts |
|---|---|---|
| `fantasycalc.values` | critical | `player.sleeperId`, `position`, `value`, `positionRank` (+ via our value service) |
| `nflverse.defense_rankings` | critical | 32 teams × QB/RB/WR/TE via our analyzer, `source==nflverse` |
| `nflverse.usage_columns` | critical | player_stats parses with `fantasy_points_ppr` + touches |
| `sleeper.state` | critical | `week`/`season`/`season_type` |
| `sleeper.week_stats` | critical | `off_snp`/`tm_off_snp`/`rec_tgt` (snap%/usage enrichment) |
| `sleeper.players` / `espn.teams` / `espn.news` | warn | shape sanity |

- Where possible a check drives our **own code** (so it also catches our parsing
  breaking); field-level checks hit the raw API to pinpoint upstream changes.
- **Season-resilient**: auto-falls back to the newest published season, so it
  stays green year-round. (It already surfaced that nflverse hasn't published the
  2025 CSV yet — handled gracefully.)
- One source being down doesn't abort the others.

## Wiring
Daily, **non-PR-blocking** `contracts.yml` (+ manual dispatch). A **critical**
failure turns the job red and GitHub notifies; warn failures are reported only.
Offline runner tests in `tests/`. **Verified live: 8/8 pass.** Suite green (793).

🤖 Erstellt mit Claude Code