### PR TITLE
feat(evals): agent tool-routing evals (Eval Layer C)

### DIFF
--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -1,0 +1,40 @@
+name: Agent Evals
+
+# Layer C — LLM tool-routing evals. On-demand only (it calls the model and costs
+# tokens). Needs an ANTHROPIC_API_KEY repo secret; without it the run skips
+# gracefully. The offline guards (scenario/schema/registry) run in the normal
+# test suite, so tool-description regressions are still caught on every PR.
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Anthropic model id"
+        default: "claude-sonnet-5"
+      threshold:
+        description: "Minimum pass rate (0-1)"
+        default: "0.8"
+
+jobs:
+  routing:
+    name: Tool-routing eval
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e . anthropic
+
+      - name: Run agent tool-routing eval
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          AGENT_EVAL_MODEL: ${{ github.event.inputs.model }}
+        run: |
+          python -m evals.agent.run --threshold "${{ github.event.inputs.threshold }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Evals — agent tool-routing** (`evals/agent/`, Eval Layer C): scenarios of
+  realistic prompts → the tool(s) an assistant should call, with tool schemas
+  derived from the live registry. A key-gated runner checks the model routes
+  correctly (single-turn); offline guards (scenario/schema/registry validity,
+  "every tool still has a description") run in normal CI so tool-description
+  regressions are caught on every PR. On-demand `agent-evals.yml` workflow.
 - **Evals — data-source contract checks** (`evals/contracts/`, Eval Layer B): a
   daily, non-blocking `contracts.yml` workflow that hits FantasyCalc / nflverse /
   Sleeper / ESPN and asserts the fields we depend on (`sleeperId`, `off_snp`,

--- a/evals/README.md
+++ b/evals/README.md
@@ -15,7 +15,8 @@ different places and run on different cadences.
 | **B. Contract checks** | Do the data sources & tools still return the schema we depend on? | `tests/` (offline) + `evals/contracts/` (live, scheduled) | PR + scheduled |
 | **C. Agent / tool-use** | Does an LLM *use* the tools correctly and safely? | `evals/agent/` | on tool-description changes |
 
-> **Layers A and B are implemented.** Layer C is on the roadmap (see the bottom).
+> **All three layers are implemented.** Layer C's live run is gated behind an
+> API key; its offline guards run in normal CI.
 
 Why the split? The fast unit tests (`tests/`, PR-blocking) prove the code *runs*.
 Evals prove the code is *right about football* — which needs real historical data
@@ -204,16 +205,50 @@ but don't fail the job. Offline runner tests live in `tests/test_eval_contracts.
 
 ---
 
+## Layer C — agent / tool-use evals (`evals/agent/`)
+
+Does an LLM using our tools pick the **right tool** for a request? A wrong tool
+(or bad args) means a wrong answer no matter how good the analytics are — and
+tool *descriptions* are what drive that choice, so this guards them.
+
+- **Scenarios** (`scenarios.py`): realistic prompts → the tool(s) a good assistant
+  should call (any-of), plus optional argument assertions.
+- **Tool schemas** (`tools.py`): derived from the live `tool_registry` (name +
+  docstring + signature), so the eval sees exactly what production exposes. Pure
+  and offline.
+- **Runner** (`run.py`): single-turn routing — attach the tool schemas, ask the
+  model each prompt, and check it *chose* an acceptable tool with sensible args
+  (we inspect the `tool_use`, we don't execute the tool). Highest signal, lowest
+  cost.
+
+```bash
+export ANTHROPIC_API_KEY=...            # required for the live run
+python -m evals.agent.run --model claude-sonnet-5 --threshold 0.8
+# no key -> skips gracefully (exit 0)
+```
+
+Runs **on demand** via `.github/workflows/agent-evals.yml` (needs the
+`ANTHROPIC_API_KEY` repo secret; costs tokens). The **offline guards** —
+scenario/schema/registry validity and "every tool still has a description" — run
+in the normal test suite (`tests/test_agent_scenarios.py`), so tool-description
+regressions are caught on every PR without a key.
+
+> Not yet run against the live model in this repo (no key configured here). Add
+> the `ANTHROPIC_API_KEY` secret and dispatch the workflow to get routing numbers.
+
+---
+
 ## Roadmap
 
 - ~~Apply the finding: position-aware matchup multipliers, then re-measure.~~ ✅ done.
 - ~~Layer B — live source contract checks.~~ ✅ done (`evals/contracts/`).
+- ~~Layer C — agent tool-routing evals.~~ ✅ done (`evals/agent/`).
 - **More Layer A targets:** backtest start/sit hit-rate, defense-ranking
   predictive validity (split-sample), FAAB bid ↔ realized value, and playoff-odds
   **calibration** (Brier score) once multi-season snapshots exist.
-- **Layer C — agent evals** (`evals/agent/`): prompt → expected tool selection +
-  answer assertions (incl. "must not present fallback/stale data as confident"),
-  run against an LLM with the MCP server attached.
+- **Deeper Layer C:** faithfulness/safety judging (execute the tool, then check
+  the rendered answer doesn't present fallback/stale/unknown data as confident) —
+  needs a multi-turn loop + LLM-as-judge.
 
 ## CI
 The backtest runs in a **scheduled, non-PR-blocking** workflow

--- a/evals/agent/__init__.py
+++ b/evals/agent/__init__.py
@@ -1,0 +1,10 @@
+"""Agent / tool-use evals (Eval Layer C).
+
+Given a natural-language prompt, does an LLM using our MCP tools pick the *right*
+tool(s) with sensible args? The tool schemas are derived from the live tool
+registry, so this evaluates the tools an assistant actually sees.
+
+The live run needs an ``ANTHROPIC_API_KEY`` (it calls the model); the scenario
+set, schema builder and registry guards are validated offline in
+``tests/test_agent_scenarios.py``.
+"""

--- a/evals/agent/run.py
+++ b/evals/agent/run.py
@@ -1,0 +1,111 @@
+"""
+Agent tool-routing eval (Eval Layer C).
+
+For each scenario we ask the model (with our MCP tool schemas attached) to answer
+a user prompt, and check that it chooses an acceptable tool with sensible args.
+This is single-turn routing — we inspect what the model *wants* to call; we don't
+execute the tools. That's the highest-signal, lowest-cost slice of Layer C.
+
+Requires ANTHROPIC_API_KEY. Without it the run is skipped (exit 0) so it degrades
+gracefully; with it, the process exits non-zero if the pass rate drops below the
+threshold (regression signal).
+
+Run: python -m evals.agent.run   [--model claude-sonnet-5] [--threshold 0.8]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import Any, Dict, List
+
+from .scenarios import SCENARIOS
+from .tools import anthropic_tools_from_registry
+
+SYSTEM = (
+    "You are a fantasy football assistant with tools for an NFL analytics server. "
+    "When the user asks something a tool can answer, call the most appropriate tool "
+    "with the arguments you can infer from the message. Prefer a tool over a plain "
+    "text answer whenever one fits."
+)
+
+DEFAULT_MODEL = os.getenv("AGENT_EVAL_MODEL", "claude-sonnet-5")
+
+
+def _tool_calls(resp) -> List[Any]:
+    return [b for b in resp.content if getattr(b, "type", None) == "tool_use"]
+
+
+def _check_args(call_input: Dict[str, Any], expected: Dict[str, Any]) -> List[str]:
+    """Return a list of arg problems (empty = all good)."""
+    problems = []
+    for key, want in (expected or {}).items():
+        if key not in call_input or call_input[key] in (None, ""):
+            problems.append(f"missing arg '{key}'")
+        elif want is not None and str(call_input[key]) != str(want):
+            problems.append(f"{key}={call_input[key]!r} != {want!r}")
+    return problems
+
+
+def run(model: str = DEFAULT_MODEL) -> List[Dict[str, Any]]:
+    import anthropic  # lazy: only needed for the live run
+
+    client = anthropic.Anthropic()
+    tools = anthropic_tools_from_registry()
+    results = []
+    for sc in SCENARIOS:
+        entry = {"id": sc["id"], "expect": sc["expect"]}
+        try:
+            resp = client.messages.create(
+                model=model,
+                max_tokens=1024,
+                system=SYSTEM,
+                tools=tools,
+                tool_choice={"type": "auto"},
+                messages=[{"role": "user", "content": sc["prompt"]}],
+            )
+            calls = _tool_calls(resp)
+            called = [c.name for c in calls]
+            entry["called"] = called
+            hit = next((c for c in calls if c.name in sc["expect"]), None)
+            if not hit:
+                entry.update(ok=False, reason=f"called {called or 'nothing'}; expected one of {sc['expect']}")
+            else:
+                problems = _check_args(hit.input or {}, sc.get("args"))
+                entry.update(ok=not problems, reason="; ".join(problems) if problems else "ok")
+        except Exception as e:  # noqa: BLE001
+            entry.update(ok=False, called=[], reason=f"error: {type(e).__name__}: {e}")
+        results.append(entry)
+    return results
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Agent tool-routing eval (Layer C)")
+    ap.add_argument("--model", default=DEFAULT_MODEL)
+    ap.add_argument("--threshold", type=float, default=0.8, help="min pass rate")
+    args = ap.parse_args()
+
+    if not os.getenv("ANTHROPIC_API_KEY"):
+        print("SKIPPED: ANTHROPIC_API_KEY not set — agent eval needs it to call the model.")
+        print("Set the key (or the ANTHROPIC_API_KEY repo secret) to run this eval.")
+        return 0
+
+    print("=" * 78)
+    print(f"AGENT TOOL-ROUTING EVAL — model={args.model}, {len(SCENARIOS)} scenarios")
+    print("=" * 78)
+    results = run(args.model)
+    passed = 0
+    for r in results:
+        icon = "✅" if r["ok"] else "❌"
+        print(f"  {icon} {r['id']:<20} -> {', '.join(r.get('called') or ['-']):<28} [{r['reason']}]")
+        passed += 1 if r["ok"] else 0
+    rate = passed / len(results) if results else 0.0
+    print("-" * 78)
+    print(f"  pass rate {passed}/{len(results)} = {rate:.0%} (threshold {args.threshold:.0%})")
+    print("=" * 78)
+    return 0 if rate >= args.threshold else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/evals/agent/scenarios.py
+++ b/evals/agent/scenarios.py
@@ -1,0 +1,95 @@
+"""Tool-routing scenarios for the agent eval.
+
+Each scenario is a realistic user prompt plus the tool(s) a good assistant should
+call. ``expect`` is an *any-of* list (several tools can be reasonable). ``args``
+optionally asserts the model extracted an obvious argument — value ``None`` means
+"just present".
+"""
+
+SCENARIOS = [
+    # --- Drafting -----------------------------------------------------------
+    {
+        "id": "draft_pick_live",
+        "prompt": "I'm in Sleeper draft 998877 at draft slot 7 and I'm on the clock. Who should I take right now?",
+        "expect": ["recommend_draft_pick"],
+        "args": {"draft_id": "998877", "my_slot": 7},
+    },
+    {
+        "id": "draft_board",
+        "prompt": "Build me a draft board for a 12-team full-PPR redraft league.",
+        "expect": ["get_draft_board"],
+    },
+    {
+        "id": "simulate_draft",
+        "prompt": "Run 100 mock drafts from the 3rd pick in a 12-team PPR league and show my likely roster.",
+        "expect": ["simulate_draft"],
+        "args": {"my_slot": 3},
+    },
+    # --- Values & trades ----------------------------------------------------
+    {
+        "id": "player_value",
+        "prompt": "What is Bijan Robinson worth in a 12-team PPR league?",
+        "expect": ["get_player_value", "get_player_values"],
+    },
+    {
+        "id": "trade_fairness",
+        "prompt": "In league 555, is it fair if roster 1 gives players 4034 and 4035 to roster 2 for player 4046?",
+        "expect": ["analyze_trade"],
+        "args": {"league_id": "555"},
+    },
+    # --- Weekly management --------------------------------------------------
+    {
+        "id": "faab_bid",
+        "prompt": "How much of my FAAB budget should I bid on player 6790 in league 555 for my roster 3?",
+        "expect": ["recommend_faab_bid"],
+        "args": {"league_id": "555"},
+    },
+    {
+        "id": "lineup",
+        "prompt": "Here's my week-6 roster with players, teams and opponents — set my optimal starting lineup.",
+        "expect": ["analyze_full_lineup", "get_roster_recommendations"],
+    },
+    {
+        "id": "start_sit_compare",
+        "prompt": "Should I start Player A (WR, MIA vs NE) or Player B (RB, SF vs ARI) in my flex this week?",
+        "expect": ["compare_players_for_slot", "get_start_sit_recommendation", "get_roster_recommendations"],
+    },
+    {
+        "id": "matchup",
+        "prompt": "How tough is the WR matchup against the Kansas City defense?",
+        "expect": ["get_matchup_difficulty"],
+    },
+    {
+        "id": "injuries",
+        "prompt": "Give me the high-confidence injuries for KC and SF.",
+        "expect": ["get_high_confidence_injuries", "get_injury_report"],
+    },
+    {
+        "id": "waiver_dashboard",
+        "prompt": "Show me the waiver-wire dashboard for league 555.",
+        "expect": ["get_waiver_wire_dashboard", "get_waiver_log"],
+        "args": {"league_id": "555"},
+    },
+    {
+        "id": "trending",
+        "prompt": "Who are the most-added players across Sleeper right now?",
+        "expect": ["get_trending_players"],
+    },
+    # --- Strategy -----------------------------------------------------------
+    {
+        "id": "playoff_odds",
+        "prompt": "What are my playoff odds in league 555?",
+        "expect": ["get_playoff_odds"],
+        "args": {"league_id": "555"},
+    },
+    {
+        "id": "find_leagues",
+        "prompt": "My Sleeper username is gridiron_gary — find my leagues for the 2026 season.",
+        "expect": ["get_user", "get_user_leagues"],
+    },
+    {
+        "id": "stacks",
+        "prompt": "Which games this week are best for a QB + WR stack?",
+        "expect": ["get_stack_opportunities", "get_vegas_lines"],
+    },
+]

--- a/evals/agent/tools.py
+++ b/evals/agent/tools.py
@@ -1,0 +1,75 @@
+"""Build Anthropic tool definitions from the live MCP tool registry.
+
+An assistant routes on tool **name + description + input schema**. We derive those
+straight from `tool_registry.get_all_tools()` (introspecting each function's
+signature and docstring), so the eval sees exactly the tools production exposes.
+Pure/offline — no network, no API key.
+"""
+
+from __future__ import annotations
+
+import inspect
+import typing
+from typing import Any, Callable, Dict, List
+
+# Params that are injected internally, never chosen by the model.
+_SKIP_PARAMS = {"self", "db"}
+
+
+def _json_type(annotation: Any) -> Dict[str, Any]:
+    """Map a Python annotation to a (permissive) JSON-schema type."""
+    if annotation is inspect._empty:  # no annotation
+        return {"type": "string"}
+    origin = typing.get_origin(annotation)
+    if origin is typing.Union:  # Optional[X] / Union -> first non-None arg
+        args = [a for a in typing.get_args(annotation) if a is not type(None)]
+        return _json_type(args[0]) if args else {"type": "string"}
+    if annotation is str:
+        return {"type": "string"}
+    if annotation is bool:
+        return {"type": "boolean"}
+    if annotation is int:
+        return {"type": "integer"}
+    if annotation is float:
+        return {"type": "number"}
+    if origin in (list, typing.List):
+        return {"type": "array"}
+    if origin in (dict, typing.Dict):
+        return {"type": "object"}
+    return {"type": "string"}
+
+
+def _description(func: Callable) -> str:
+    doc = (inspect.getdoc(func) or "").strip()
+    # First paragraph is the summary; strip the LLM-agent boilerplate line.
+    para = doc.split("\n\n")[0].strip()
+    return para[:1024] or func.__name__
+
+
+def build_tool(func: Callable) -> Dict[str, Any]:
+    """Anthropic tool def for one registry function."""
+    sig = inspect.signature(func)
+    props: Dict[str, Any] = {}
+    required: List[str] = []
+    for name, p in sig.parameters.items():
+        if name in _SKIP_PARAMS:
+            continue
+        props[name] = _json_type(p.annotation)
+        if p.default is inspect._empty:
+            required.append(name)
+    return {
+        "name": func.__name__,
+        "description": _description(func),
+        "input_schema": {"type": "object", "properties": props, "required": required},
+    }
+
+
+def anthropic_tools_from_registry() -> List[Dict[str, Any]]:
+    """All registered MCP tools as Anthropic tool definitions."""
+    from nfl_mcp import tool_registry
+    return [build_tool(fn) for fn in tool_registry.get_all_tools()]
+
+
+def registry_tool_names() -> set:
+    from nfl_mcp import tool_registry
+    return {fn.__name__ for fn in tool_registry.get_all_tools()}

--- a/tests/test_agent_scenarios.py
+++ b/tests/test_agent_scenarios.py
@@ -1,0 +1,54 @@
+"""Offline guards for the agent eval (Layer C) — no network / no API key.
+
+These validate the durable parts (scenario set, schema builder, registry) so a
+broken scenario or a tool losing its description is caught in normal CI, even
+though the live LLM run is gated behind ANTHROPIC_API_KEY.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from evals.agent import tools as T
+from evals.agent.scenarios import SCENARIOS
+
+
+def test_schema_builder_covers_all_tools():
+    defs = T.anthropic_tools_from_registry()
+    assert len(defs) >= 30
+    for d in defs:
+        assert d["name"]
+        assert d["description"], f"{d['name']} has no description (hurts routing)"
+        assert d["input_schema"]["type"] == "object"
+        assert "properties" in d["input_schema"]
+
+
+def test_scenarios_well_formed():
+    ids = [s["id"] for s in SCENARIOS]
+    assert len(ids) == len(set(ids)), "duplicate scenario ids"
+    for s in SCENARIOS:
+        assert s["prompt"].strip()
+        assert s["expect"], f"{s['id']} has no expected tools"
+
+
+def test_expected_tools_exist_in_registry():
+    names = T.registry_tool_names()
+    for s in SCENARIOS:
+        for tool in s["expect"]:
+            assert tool in names, f"scenario {s['id']} expects unknown tool '{tool}'"
+
+
+def test_scenario_args_are_real_params():
+    defs = {d["name"]: d for d in T.anthropic_tools_from_registry()}
+    for s in SCENARIOS:
+        for key in (s.get("args") or {}):
+            in_some = any(key in defs[t]["input_schema"]["properties"] for t in s["expect"])
+            assert in_some, f"scenario {s['id']} asserts arg '{key}' not on any expected tool"
+
+
+def test_required_params_detected():
+    defs = {d["name"]: d for d in T.anthropic_tools_from_registry()}
+    # sanity: a tool with a required-first-arg is captured
+    assert "draft_id" in defs["recommend_draft_pick"]["input_schema"]["required"]
+    assert "league_id" in defs["get_playoff_odds"]["input_schema"]["required"]


### PR DESCRIPTION
Adds **Eval Layer C** — does an LLM using our tools pick the *right* tool for a
request? Wrong tool ⇒ wrong answer, no matter how good the analytics are, and tool
**descriptions** drive that choice.

## What
- `scenarios.py` — 15 realistic prompts → the tool(s) a good assistant should call
  (any-of) + optional argument assertions (e.g. `draft_id`, `league_id`).
- `tools.py` — Anthropic tool defs derived from the **live `tool_registry`**
  (name + docstring + signature), so the eval sees exactly what production
  exposes. Pure/offline (70 tools, all with descriptions & correct required args).
- `run.py` — single-turn routing runner: attach the schemas, ask the model each
  prompt, check it *chose* an acceptable tool with sensible args (inspects the
  `tool_use`; doesn't execute tools). Highest signal, lowest cost.

## Gating
- Live run needs `ANTHROPIC_API_KEY` (costs tokens) → **on-demand** `agent-evals.yml`
  workflow; skips gracefully (exit 0) without a key.
- **Offline guards** run in normal CI (`tests/test_agent_scenarios.py`): scenario /
  schema / registry validity and "every tool still has a description" — so
  tool-description regressions are caught on every PR, no key needed.

> The live model run was **not** executed in this repo (no key configured here).
> Add the `ANTHROPIC_API_KEY` secret and dispatch the workflow to get routing numbers.

Suite green: **798 passing** on 3.11 & 3.12.

🤖 Erstellt mit Claude Code