### PR TITLE
fix+feat: harden draft flow against real Sleeper data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Draft starter requirements now count all Sleeper flex variants** — validating
+  the live draft flow against a real 10-team league surfaced that
+  `slots_rec_flex` (and `slots_wr_te`) were ignored, undercounting FLEX and
+  skewing the roster-need weighting in `recommend_draft_pick`.
+
 ### Added
+- **Pre-draft flight check** (`evals/live/validate_draft.py`): runs the real
+  Sleeper draft flow (`get_draft` → `get_draft_picks` → `recommend_draft_pick`)
+  against your actual league/draft by username, league id or draft id — a
+  green/red pre-flight before draft day. Verified end-to-end against a real
+  completed Sleeper draft.
 - **Evals — agent tool-routing** (`evals/agent/`, Eval Layer C): scenarios of
   realistic prompts → the tool(s) an assistant should call, with tool schemas
   derived from the live registry. A key-gated runner checks the model routes

--- a/README.md
+++ b/README.md
@@ -161,6 +161,13 @@ it — just ask the assistant, which uses the built-in tools:
 > *"I'm in draft `<draft_id>` at slot 7 — who should I take right now?"*
 > → `recommend_draft_pick`
 
+> **Pre-draft flight check** — validate the whole draft flow against your real
+> league before draft day (drives the live Sleeper API through our code):
+> ```bash
+> python -m evals.live.validate_draft --username your_sleeper_name --season 2026
+> # or --league-id <id> / --draft-id <id>
+> ```
+
 **During the season** (with `league_id`):
 > *"Set my week-5 lineup, tell me my best FAAB bid on `<player>`, and what my
 > playoff odds are if I win vs lose this week."*

--- a/evals/live/__init__.py
+++ b/evals/live/__init__.py
@@ -1,0 +1,5 @@
+"""Live integration smoke tests you run by hand against real Sleeper data.
+
+Unlike the unit tests (mocked) and the scheduled evals, these drive the real code
+paths against a real league/draft — a pre-flight check before draft day.
+"""

--- a/evals/live/validate_draft.py
+++ b/evals/live/validate_draft.py
@@ -1,0 +1,143 @@
+"""
+Pre-draft flight check — validate the whole Sleeper draft flow against a REAL
+draft, before draft day.
+
+Drives the actual code paths (sleeper_tools.get_draft / get_draft_picks and
+draft_tools.recommend_draft_pick) so any mismatch between our parsing and the live
+Sleeper API surfaces now, not while you're on the clock.
+
+Usage (any one of):
+    python -m evals.live.validate_draft --draft-id 998877
+    python -m evals.live.validate_draft --league-id 555         # newest draft
+    python -m evals.live.validate_draft --username your_name --season 2026
+Optionally: --my-slot 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import tempfile
+from typing import List, Optional
+
+from nfl_mcp import sleeper_tools as st, draft_tools as dt
+from nfl_mcp.database import NFLDatabase
+
+_results: List[dict] = []
+
+
+def _ok(name: str, detail: str):
+    _results.append({"name": name, "ok": True, "detail": detail})
+    print(f"  ✅ {name:<26} {detail}")
+
+
+def _fail(name: str, detail: str):
+    _results.append({"name": name, "ok": False, "detail": detail})
+    print(f"  ❌ {name:<26} {detail}")
+
+
+async def _resolve_draft_id(args) -> Optional[str]:
+    if args.draft_id:
+        return args.draft_id
+    if args.league_id:
+        r = await st.get_league_drafts(args.league_id)
+        drafts = r.get("drafts", []) if r.get("success") else []
+        if drafts:
+            _ok("resolve.league_drafts", f"{len(drafts)} draft(s); using {drafts[0].get('draft_id')}")
+            return drafts[0].get("draft_id")
+        _fail("resolve.league_drafts", f"no drafts for league {args.league_id}: {r.get('error')}")
+        return None
+    if args.username:
+        u = await st.get_user(args.username)
+        if not (u.get("success") and u.get("user")):
+            _fail("resolve.user", f"username '{args.username}' not found")
+            return None
+        uid = u["user"].get("user_id")
+        _ok("resolve.user", f"{args.username} -> {uid}")
+        for season in (args.season, args.season - 1):
+            lr = await st.get_user_leagues(uid, season)
+            for lg in (lr.get("leagues", []) if lr.get("success") else []):
+                dr = await st.get_league_drafts(lg.get("league_id"))
+                drafts = dr.get("drafts", []) if dr.get("success") else []
+                if drafts:
+                    _ok("resolve.leagues", f"{lg.get('name')} ({season}) -> draft {drafts[0].get('draft_id')}")
+                    return drafts[0].get("draft_id")
+        _fail("resolve.leagues", "no leagues with a draft found for recent seasons")
+    return None
+
+
+async def run(args) -> int:
+    print("=" * 78)
+    print("PRE-DRAFT FLIGHT CHECK")
+    print("=" * 78)
+    draft_id = await _resolve_draft_id(args)
+    if not draft_id:
+        return 1
+
+    db = NFLDatabase(tempfile.mktemp(suffix=".db"))
+
+    # 1) get_draft — settings & format parsing
+    d = await st.get_draft(draft_id)
+    if not (d.get("success") and d.get("draft")):
+        _fail("get_draft", f"{d.get('error')}")
+        return 1
+    draft = d["draft"]
+    settings = draft.get("settings", {}) or {}
+    reqs = dt._starter_requirements(settings)
+    scoring = dt._scoring_from_draft(draft)
+    _ok("get_draft", f"status={draft.get('status')} teams={settings.get('teams')} "
+                     f"scoring={scoring} starters={reqs}")
+
+    # 2) get_draft_picks — shape & player ids
+    p = await st.get_draft_picks(draft_id)
+    picks = p.get("picks", []) if p.get("success") else []
+    if not p.get("success"):
+        _fail("get_draft_picks", f"{p.get('error')}")
+        return 1
+    if picks:
+        pk = picks[0]
+        pos = (pk.get("metadata") or {}).get("position")
+        if pk.get("player_id") and pk.get("draft_slot"):
+            _ok("get_draft_picks", f"{len(picks)} picks; sample pid={pk.get('player_id')} slot={pk.get('draft_slot')} pos={pos}")
+        else:
+            _fail("get_draft_picks", f"pick shape unexpected: keys={sorted(pk.keys())}")
+    else:
+        _ok("get_draft_picks", "0 picks (draft not started yet — fine pre-draft)")
+
+    # 3) recommend_draft_pick — end-to-end (values + roster need)
+    r = await dt.recommend_draft_pick(draft_id, my_slot=args.my_slot, num_suggestions=3, db=db)
+    if not r.get("success"):
+        _fail("recommend_draft_pick", f"{r.get('error')}")
+        return 1
+    sugg = r.get("suggestions", [])
+    if sugg:
+        top = ", ".join(f"{x['name']}({x['position']})" for x in sugg)
+        _ok("recommend_draft_pick", f"picks_made={r.get('picks_made')} format={r.get('format', {}).get('scoring')} "
+                                    f"source={r.get('source')} | top: {top}")
+    else:
+        _ok("recommend_draft_pick", f"picks_made={r.get('picks_made')} (no players left / pool exhausted)")
+
+    print("-" * 78)
+    ok = sum(1 for x in _results if x["ok"])
+    crit_fail = sum(1 for x in _results if not x["ok"])
+    print(f"  {ok}/{len(_results)} checks passed, {crit_fail} failure(s)")
+    print("=" * 78)
+    return 1 if crit_fail else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Validate the Sleeper draft flow against a real draft")
+    ap.add_argument("--draft-id")
+    ap.add_argument("--league-id")
+    ap.add_argument("--username")
+    ap.add_argument("--season", type=int, default=2026)
+    ap.add_argument("--my-slot", type=int, default=1)
+    args = ap.parse_args()
+    if not (args.draft_id or args.league_id or args.username):
+        ap.error("provide one of --draft-id / --league-id / --username")
+    return asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/nfl_mcp/draft_tools.py
+++ b/nfl_mcp/draft_tools.py
@@ -199,7 +199,10 @@ def _starter_requirements(settings: Dict) -> Dict[str, int]:
             return int(s.get(k, 0) or 0)
         except (TypeError, ValueError):
             return 0
-    flex = g("slots_flex") + g("slots_wrrb_flex") + g("slots_rb_wr") + g("slots_rb_wr_te")
+    # Sleeper uses several names for flexible skill-position slots. Count them all
+    # (verified against a real league that had slots_rec_flex, which we'd missed).
+    flex = (g("slots_flex") + g("slots_wrrb_flex") + g("slots_rb_wr")
+            + g("slots_rb_wr_te") + g("slots_rec_flex") + g("slots_wr_te"))
     return {
         "QB": g("slots_qb") + g("slots_super_flex"),
         "RB": g("slots_rb"),

--- a/tests/test_draft_tools.py
+++ b/tests/test_draft_tools.py
@@ -56,6 +56,16 @@ class TestPureHelpers:
         reqs = dt._starter_requirements({"slots_qb": 1, "slots_rb": 2, "slots_wr": 3, "slots_te": 1, "slots_flex": 1})
         assert reqs == {"QB": 1, "RB": 2, "WR": 3, "TE": 1, "FLEX": 1}
 
+    def test_starter_requirements_counts_all_flex_variants(self):
+        # Real Sleeper league: flex + wrrb_flex + rec_flex = 3 flex slots; super_flex -> QB.
+        reqs = dt._starter_requirements({
+            "slots_qb": 1, "slots_rb": 2, "slots_wr": 2, "slots_te": 1,
+            "slots_flex": 1, "slots_wrrb_flex": 1, "slots_rec_flex": 1,
+            "slots_super_flex": 1,
+        })
+        assert reqs["FLEX"] == 3
+        assert reqs["QB"] == 2  # base QB + superflex
+
     def test_need_multiplier(self):
         reqs = {"QB": 1, "RB": 2, "WR": 2, "TE": 1, "FLEX": 1}
         # need a starter -> boosted


### PR DESCRIPTION
Validated the whole Sleeper **draft flow against a real completed draft** (not
just mocks) — which is exactly what surfaced a bug.

## Fix
`_starter_requirements` ignored `slots_rec_flex` (and `slots_wr_te`), so a league
with a WR/TE flex **undercounted FLEX** → skewed the roster-need weighting in
`recommend_draft_pick`. Now counts every Sleeper flex slot name. Test added.

## Feature — pre-draft flight check (`evals/live/validate_draft.py`)
Drives the real code paths (`get_draft` → `get_draft_picks` → `recommend_draft_pick`)
against your actual league, by `--username` / `--league-id` / `--draft-id`. A
green/red pre-flight before draft day.

**Verified end-to-end** against a real completed Sleeper draft (10-team, half-PPR):
`get_draft` ✅, 160 picks parsed ✅, format auto-derived ✅, live suggestions ✅ —
and the username→leagues→draft resolution chain ✅.

Docs updated (README Going Live + CHANGELOG). Suite green (799).

🤖 Erstellt mit Claude Code