### PR TITLE
docs: Draft-Day Playbook + live draft watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   skewing the roster-need weighting in `recommend_draft_pick`.
 
 ### Added
+- **Draft-Day Playbook** (`docs/DRAFT_DAY.md`) + **live "war room" watcher**
+  (`evals/live/draft_watch.py`): the playbook documents the full before/during
+  draft workflow, how to read the recommendations, and where the tool leads
+  (value rounds) vs where your judgment does (bench depth / handcuffs). The
+  watcher polls a live Sleeper draft and recommends a pick each time you're on
+  the clock, flipping to a bench-depth overlay once your starters are full.
+  Distilled from a full live run against a real Sleeper draft.
 - **Pre-draft flight check** (`evals/live/validate_draft.py`): runs the real
   Sleeper draft flow (`get_draft` → `get_draft_picks` → `recommend_draft_pick`)
   against your actual league/draft by username, league id or draft id — a

--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ it — just ask the assistant, which uses the built-in tools:
 > # or --league-id <id> / --draft-id <id>
 > ```
 
+> **Live "war room" watcher** — polls a live Sleeper draft and gives you a
+> recommendation each time you're on the clock (with a bench-depth overlay in the
+> late rounds):
+> ```bash
+> python -m evals.live.draft_watch --draft-id <draft_id> --my-slot 4
+> ```
+
+📖 **Full [Draft-Day Playbook](docs/DRAFT_DAY.md)** — before/during the draft, how
+to read the recommendations, and where the tool leads vs where your judgment does.
+
 **During the season** (with `league_id`):
 > *"Set my week-5 lineup, tell me my best FAAB bid on `<player>`, and what my
 > playoff odds are if I win vs lose this week."*

--- a/docs/DRAFT_DAY.md
+++ b/docs/DRAFT_DAY.md
@@ -1,0 +1,114 @@
+# Draft-Day Playbook
+
+How to actually draft with this server — before, during, and how to read what it
+tells you. Distilled from a full live run against a real Sleeper draft.
+
+> TL;DR: **rounds 1–8, follow the tool** (value / VBD, cliffs, runs, "elite scarce
+> position early or wait on QB"). **Bench rounds, your judgment takes over**
+> (RB/WR depth + handcuffs, byes) — pure value goes blind on deep benches.
+
+---
+
+## 1. Before the draft
+
+```bash
+# (a) Flight check — validate the whole flow against your real league, so nothing
+#     surprises you on the clock.
+python -m evals.live.validate_draft --username your_sleeper_name --season 2026
+
+# (b) Study the board — VBD-ranked, tiered, format-aware.
+#     (via your assistant / MCP client)
+get_draft_board(scoring="ppr", num_teams=12)
+
+# (c) Rehearse — 100 mock drafts from your slot to learn your realistic roster shape.
+simulate_draft(my_slot=7, num_teams=12, num_sims=100)
+```
+
+Get a **live `draft_id`** to practise against: start a **Sleeper mock draft**
+(app/website, solo-with-CPU works year-round). The id is in the URL:
+`sleeper.com/draft/nfl/<draft_id>`. Note your **slot** (draft position).
+
+---
+
+## 2. During the draft
+
+Two ways — both read the **live** Sleeper draft state:
+
+**A) Ask your assistant, each pick** (nothing to run):
+> *"I'm in draft `<draft_id>` at slot 4 — who should I take now?"*
+> → calls `recommend_draft_pick(draft_id, my_slot)`.
+
+**B) Live watcher** (a terminal "war room"):
+```bash
+python -m evals.live.draft_watch --draft-id <draft_id> --my-slot 4
+```
+It polls the draft and, each time you're on the clock, prints your roster, what's
+gone since your last pick, the top picks (with value cliffs & positional runs),
+and — once your starters are full — flips to a **bench-depth overlay**. Make your
+pick in Sleeper; it watches for your next turn. `--once` for a single check.
+
+> **Sleeper API lag:** picks can take a second or two to appear in the API. If the
+> tool seems a beat behind, re-run — `recommend_draft_pick` always re-fetches.
+
+---
+
+## 3. Reading the recommendation
+
+| Signal | Meaning | Use it to… |
+|--------|---------|-----------|
+| **VBD** | value over positional replacement | rank who's actually worth most *for a draft* |
+| **need-weighted** order | VBD × your roster need | the tool's suggested pick given your team |
+| **value cliff** | steep drop to the next player at that position | grab *this* player now or lose the tier |
+| **positional run** | many of one position going recently | that position is thinning — react |
+| **tier** | consensus tier | tier breaks = natural "reach vs wait" lines |
+
+---
+
+## 4. Strategy — where the tool leads, where you lead
+
+**Rounds 1–8 → follow the tool.** It's built for value here:
+- Take the **best value** (highest need-weighted VBD), not the flashiest name.
+- **Elite scarce position early** (an elite TE/RB) *or* **wait on QB** — in 1-QB
+  leagues, elite QBs fall; you often get a WR/RB *and* an elite QB by waiting.
+- Respect **value cliffs** (grab the last player before a drop) and **runs**.
+
+**Bench rounds → your judgment.** Pure VBD is *blind* on deep benches (it can rank
+a backup QB or a 4th TE over a useful RB/WR body). Your rules:
+- **RB/WR depth first**, especially **handcuffs to your studs** (a stud RB going
+  down with no backup is how seasons end).
+- **Don't over-stack** one position (chasing "value" into a 3rd/4th TE leaves you
+  thin where injuries actually happen — RB/WR).
+- **1 backup QB** only in the last round (bye-week fill), or skip it.
+- The watcher flags this automatically as **BENCH MODE**.
+
+---
+
+## 5. Worked example (real live mock, 12-team PPR, slot 4)
+
+| Rd | Pick | Why |
+|----|------|-----|
+| 1 | **Bijan Robinson** (RB) | Elite RB fell to 1.04 — steal; RB cliff after him |
+| 2 | **Saquon Barkley** (RB) | Top value at the turn → elite RB duo |
+| 3 | **A.J. Brown** (WR) | Best WR with a **cliff after him**; WR1 secured |
+| 4 | **Tyler Warren** (TE) | Top value + locks a scarce position |
+| 5 | **Zay Flowers** (WR) | WR2 with a cliff — QB deliberately deferred |
+| 6 | **Patrick Mahomes** (QB) | **Wait paid off**: got Flowers *and* an elite QB at 6.09 |
+| 7–8 | Kittle, Kelce (TE) | High value for FLEX — but note: this went TE-heavy |
+| 9–11 | White, Diggs, Mason (RB/WR) | **Bench mode**: overrode the tool's TE/QB picks for RB/WR depth |
+
+Lessons baked in: the value engine built an **A-grade starting core**; the
+**3-TE drift** in rounds 7–8 is exactly why the bench rounds need the human
+depth/handcuff overlay.
+
+---
+
+## 6. Full-power config (in-season)
+
+For the weekly tools that build on the draft (projections, start/sit, FAAB), run
+the server with:
+```bash
+-e NFL_MCP_ADVANCED_ENRICH=1   # real snap%/usage enrichment
+-e NFL_MCP_PREFETCH=1          # warm caches
+-e ODDS_API_KEY=...            # live Vegas game environment (optional)
+```
+See the main [README](../README.md#-going-live--use-it-from-your-ai-client).

--- a/evals/live/__init__.py
+++ b/evals/live/__init__.py
@@ -1,5 +1,11 @@
-"""Live integration smoke tests you run by hand against real Sleeper data.
+"""Live integration tools you run by hand against real Sleeper data.
 
 Unlike the unit tests (mocked) and the scheduled evals, these drive the real code
-paths against a real league/draft — a pre-flight check before draft day.
+paths against a real league/draft:
+
+- ``validate_draft`` — a pre-flight check that the whole draft flow works.
+- ``draft_watch`` — a live "war room" watcher that recommends a pick each time
+  you're on the clock.
+
+See ``docs/DRAFT_DAY.md`` for the full draft-day playbook.
 """

--- a/evals/live/draft_watch.py
+++ b/evals/live/draft_watch.py
@@ -1,0 +1,137 @@
+"""
+Live draft "war room" — watch a real Sleeper draft and get a recommendation
+each time you're on the clock.
+
+This is the reusable version of the ad-hoc loop we used to validate the draft
+flow live. Point it at a live/mock Sleeper draft and your slot; it polls the real
+draft state, and when it's your turn it prints roster context + the top picks
+(with value cliffs and positional runs). In the bench rounds it flips to a depth
+overlay (RB/WR + handcuffs), because pure VBD goes blind on deep benches.
+
+Usage:
+    python -m evals.live.draft_watch --draft-id 1384996703937003520 --my-slot 4
+    python -m evals.live.draft_watch --draft-id <id> --my-slot 4 --once   # single check
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import tempfile
+from collections import Counter
+from typing import Optional
+
+from nfl_mcp import sleeper_tools as st, draft_tools as dt
+from nfl_mcp.database import NFLDatabase
+
+VBD_POS = ("QB", "RB", "WR", "TE")
+
+
+def _starters_full(counts: dict, reqs: dict) -> bool:
+    base_full = all(counts.get(p, 0) >= reqs.get(p, 0) for p in ("QB", "RB", "WR", "TE"))
+    flex_full = dt._flex_filled(counts, reqs) >= reqs.get("FLEX", 0)
+    return base_full and flex_full
+
+
+async def _show_turn(db, draft_id: str, my_slot: int, teams: int, reqs: dict, picks, num: int):
+    n = len(picks)
+    mine = [pk for pk in picks if pk.get("draft_slot") == my_slot]
+    counts = Counter((pk.get("metadata") or {}).get("position") for pk in mine)
+    my_last = max((pk.get("pick_no", 0) for pk in mine), default=0)
+    since = [pk for pk in picks if pk.get("pick_no", 0) > my_last]
+    rnd = n // teams + 1
+
+    print("\n" + "=" * 70)
+    print(f">>> YOU'RE ON THE CLOCK — pick #{n + 1} (round {rnd}), slot {my_slot}")
+    print("=" * 70)
+    team = [f"{(pk.get('metadata') or {}).get('last_name','?')}"
+            f"({(pk.get('metadata') or {}).get('position','?')})" for pk in mine]
+    print("Your roster:", team or "(empty)")
+    if since:
+        print(f"Gone since your last pick ({len(since)}): "
+              f"{dict(Counter((pk.get('metadata') or {}).get('position') for pk in since))}")
+
+    r = await dt.recommend_draft_pick(draft_id, my_slot=my_slot, num_suggestions=num, db=db)
+    if not r.get("success"):
+        print("recommend error:", r.get("error"))
+        return
+
+    bench_mode = _starters_full(counts, reqs)
+    if bench_mode:
+        bp = r.get("best_available_by_position") or {}
+        print("\nBENCH MODE — starters filled. Prioritise RB/WR depth + handcuffs;")
+        print("ignore backup QB / extra TE (pure VBD is blind on deep benches).")
+        for pos in ("RB", "WR"):
+            if pos in bp:
+                print(f"  best {pos} available: {bp[pos]['name']} (vbd {bp[pos]['vbd']})")
+    else:
+        print("\nTop picks (by need-weighted value):")
+        for s in r.get("suggestions", []):
+            print(f"  {s['name']:<22} {s['position']:<3} vbd={s['vbd']:<7} :: {'; '.join(s['reasoning'])}")
+        if r.get("value_cliffs"):
+            print("  value cliffs:", r["value_cliffs"])
+    top = r.get("top_pick")
+    if top:
+        print(f"\n=> Suggested: {top['name']} ({top['position']})"
+              + (" — but in bench mode, take the RB/WR body above" if bench_mode else ""))
+
+
+async def _final(picks, my_slot):
+    mine = [pk for pk in picks if pk.get("draft_slot") == my_slot]
+    print("\n" + "=" * 70)
+    print("DRAFT COMPLETE — your roster:")
+    for pk in sorted(mine, key=lambda x: x.get("pick_no", 0)):
+        m = pk.get("metadata") or {}
+        print(f"  R{pk.get('round')}  {m.get('first_name','')} {m.get('last_name','')} ({m.get('position')})")
+    print("=" * 70)
+
+
+async def run(draft_id: str, my_slot: int, interval: int, num: int, once: bool):
+    db = NFLDatabase(tempfile.mktemp(suffix=".db"))
+    d = await st.get_draft(draft_id)
+    if not (d.get("success") and d.get("draft")):
+        print("Could not load draft:", d.get("error"))
+        return 1
+    s = d["draft"].get("settings", {}) or {}
+    teams = int(s.get("teams", 12) or 12)
+    rounds = int(s.get("rounds", 15) or 15)
+    reqs = dt._starter_requirements(s)
+    print(f"Watching draft {draft_id}: {teams}-team {dt._scoring_from_draft(d['draft'])} "
+          f"snake, {rounds} rounds. You are slot {my_slot}. Starters: {reqs}")
+
+    recommended_for = -1
+    while True:
+        p = await st.get_draft_picks(draft_id)
+        picks = p.get("picks", []) if p.get("success") else []
+        n = len(picks)
+        if n >= teams * rounds:
+            await _final(picks, my_slot)
+            return 0
+        on_clock = dt._snake_slot(n, teams)
+        if on_clock == my_slot and n != recommended_for:
+            await _show_turn(db, draft_id, my_slot, teams, reqs, picks, num)
+            recommended_for = n
+            if once:
+                return 0
+            print(f"\n(make your pick in Sleeper; watching for the next turn — Ctrl-C to stop)")
+        await asyncio.sleep(interval)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Live Sleeper draft watcher")
+    ap.add_argument("--draft-id", required=True)
+    ap.add_argument("--my-slot", type=int, required=True)
+    ap.add_argument("--interval", type=int, default=8, help="poll seconds")
+    ap.add_argument("--num", type=int, default=6, help="suggestions to show")
+    ap.add_argument("--once", action="store_true", help="single check, don't loop")
+    args = ap.parse_args()
+    try:
+        return asyncio.run(run(args.draft_id, args.my_slot, args.interval, args.num, args.once))
+    except KeyboardInterrupt:
+        print("\nstopped.")
+        return 0
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())


### PR DESCRIPTION
Documents the whole live-draft workflow and turns the ad-hoc watcher we used to
validate the Sleeper integration into durable, committed artifacts.

- **`docs/DRAFT_DAY.md`** — before/during-draft playbook: flight check → study
  board → simulate; two ways to run it live (ask the assistant / the watcher);
  how to read the signals (VBD, value cliffs, positional runs, need); and the
  key strategy — **rounds 1–8 follow the tool, bench rounds your judgment**
  (RB/WR depth + handcuffs; pure VBD is blind on deep benches). Includes a worked
  real-mock example (the A-grade slot-4 roster we drafted live).
- **`evals/live/draft_watch.py`** — reusable "war room" watcher: polls a live
  Sleeper draft, recommends a pick each time you're on the clock (with cliffs &
  runs), and flips to a **bench-depth overlay** once starters are full. `--once`
  for a single check. Smoke-tested against a real draft.
- Linked from README (Going Live) + `evals/live`; CHANGELOG updated.

🤖 Erstellt mit Claude Code