### PR TITLE
chore(release): prep v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-26
+
 ### Fixed
 - **Draft starter requirements now count all Sleeper flex variants** — validating
   the live draft flow against a real 10-team league surfaced that
@@ -113,5 +115,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Aligned `requirements.txt` and `pyproject.toml` dependencies; documented
   `ODDS_API_KEY`; removed a stray dev script.
 
-[Unreleased]: https://github.com/gtonic/nfl_mcp/compare/v0.5.16...HEAD
+[Unreleased]: https://github.com/gtonic/nfl_mcp/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/gtonic/nfl_mcp/compare/v0.5.16...v0.6.0
 [0.5.16]: https://github.com/gtonic/nfl_mcp/releases/tag/v0.5.16

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ docker run --rm -p 9000:9000 \
 
 ### Quick Overview
 
-The NFL MCP Server provides **60+ MCP tools** organized into these categories:
+The NFL MCP Server provides **70+ MCP tools** organized into these categories:
 
 #### 🏈 NFL Information (9 tools)
 - `get_nfl_news` - Latest NFL news from ESPN
@@ -523,7 +523,7 @@ Returns server health status.
 {
   "status": "healthy",
   "service": "NFL MCP Server", 
-  "version": "0.1.0"
+  "version": "0.6.0"
 }
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,19 +4,18 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfl_mcp"
-version = "0.5.16"
+version = "0.6.0"
 description = "NFL MCP Server - Fantasy Football Analysis via Model Context Protocol"
 authors = [{name = "NFL MCP Team", email = "nfl@example.com"}]
 license = {text = "MIT"}
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Release prep for **v0.6.0** (30 commits / 16 features since v0.5.16: value layer, draft assistant, projections, FAAB, playoff odds, real nflverse data, 3-layer evals, fastmcp stable 3.4.4, …).

- version 0.5.16 → 0.6.0
- **fix:** `requires-python` >=3.9 → **>=3.10** (fastmcp 3.4.4 needs 3.10+; a 3.9 install would fail); drop 3.9 classifier
- CHANGELOG: cut the `[0.6.0]` section + compare links
- README: tool count 60+ → 70+; stale health-example version 0.1.0 → 0.6.0

After merge: tag `v0.6.0` + GitHub release → publishes `ghcr.io/gtonic/nfl_mcp:0.6.0` and `:0.6`.

🤖 Erstellt mit Claude Code