### PR TITLE
feat: strength-of-schedule tools (ROS / playoff weeks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Strength-of-schedule tools** (`nfl_mcp/sos_tools.py`) — new MCP tools
+  `get_strength_of_schedule` (arbitrary week range) and `get_playoff_sos`
+  (fantasy weeks 15-17) that rank NFL teams by schedule difficulty per position
+  using the existing defense-vs-position rankings. Reports a 0-100 ease score
+  (higher = softer schedule), ranks teams easiest-first, and — before a season
+  has live data — transparently falls back to the prior season's defense
+  rankings (`strength_source_season` / `strength_is_fallback`). Purely additive;
+  does not touch the projection engine. Verified end-to-end against real 2025
+  playoff-week schedules.
 - **Pinned dependency lockfile for reproducible Docker builds** — added
   `requirements.lock` (228 fully-pinned transitive deps, generated via
   `uv pip compile requirements.txt --python-version 3.11`). The Dockerfile now

--- a/nfl_mcp/sleeper_tools.py
+++ b/nfl_mcp/sleeper_tools.py
@@ -2085,16 +2085,23 @@ async def _fetch_week_player_snaps(season: int, week: int):
         logger.error(f"[Fetch Snaps] Failed for season={season}, week={week}: {e}", exc_info=True)
         return []
 
-async def _fetch_week_schedule(season: int, week: int):
+async def _fetch_week_schedule(season: int, week: int, force: bool = False):
     """Fetch weekly schedule from ESPN scoreboard API (best-effort).
 
     Returns list of bidirectional game rows for upsert_schedule_games.
     If advanced enrichment disabled or failure occurs, returns empty list.
-    
+
+    Args:
+        season: NFL season year.
+        week: Regular-season week (1-18).
+        force: Fetch even when NFL_MCP_ADVANCED_ENRICH is off. Used by callers
+            (e.g. strength-of-schedule) for which the schedule *is* the product,
+            not opportunistic enrichment.
+
     Uses retry logic with exponential backoff and circuit breaker pattern.
     Includes response validation to ensure data quality.
     """
-    if not ADVANCED_ENRICH_ENABLED:
+    if not ADVANCED_ENRICH_ENABLED and not force:
         logger.debug("[Fetch Schedule] Skipped: NFL_MCP_ADVANCED_ENRICH not enabled")
         return []
     

--- a/nfl_mcp/sos_tools.py
+++ b/nfl_mcp/sos_tools.py
@@ -1,0 +1,300 @@
+"""Strength-of-schedule (SOS) tools.
+
+Rank NFL teams by how easy or hard their upcoming — or fantasy-playoff-week
+(15-17) — schedule is, per fantasy position, using defense-vs-position
+rankings. Purely additive: this does NOT touch the projection engine. Useful
+for rest-of-season planning, trade-deadline calls and playoff-week stash
+decisions (which streamer / stash has the softest championship-run schedule).
+
+Defense strength comes from ``matchup_tools`` (nflverse-derived: rank 1 =
+toughest defense, 32 = easiest). Before a season has data (preseason) the prior
+season is used as the strength prior; the response reports which season was used
+and whether it fell back to placeholder data.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional
+
+from . import matchup_tools, sleeper_tools
+from .errors import create_success_response, handle_http_errors, handle_validation_error
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SOS_POSITIONS = ["QB", "RB", "WR", "TE"]
+PLAYOFF_WEEKS = (15, 16, 17)
+_WEEK_MIN = 1
+_WEEK_MAX = 18
+
+
+def _ease_score(rank: float) -> float:
+    """Map a defense rank (1 = toughest .. 32 = easiest) to a 0-100 ease score.
+
+    Higher = easier schedule. Rank 1 -> 0.0, rank 32 -> 100.0.
+    """
+    r = max(1.0, min(32.0, float(rank)))
+    return round((r - 1) / 31 * 100, 1)
+
+
+def _all_fallback(rankings: Optional[Dict[str, List[Dict]]]) -> bool:
+    """True when every ranking entry is placeholder data (no live season yet)."""
+    if not rankings:
+        return True
+    for teams in rankings.values():
+        for team in teams:
+            if not team.get("is_fallback"):
+                return False
+    return True
+
+
+def compute_team_sos(
+    opponents_by_week: Dict[str, Dict[int, Optional[str]]],
+    rankings: Dict[str, List[Dict]],
+    positions: List[str],
+    analyzer,
+) -> Dict[str, Dict]:
+    """Pure aggregation of per-team, per-position SOS over the given weeks.
+
+    Args:
+        opponents_by_week: ``{team: {week: opponent_abbr_or_None}}``.
+        rankings: defense rankings from ``fetch_defense_rankings``.
+        positions: positions to grade (e.g. ``["QB", "RB", "WR", "TE"]``).
+        analyzer: a ``DefenseRankingsAnalyzer`` (used only for
+            ``get_matchup_difficulty``), so this stays unit-testable with a stub.
+
+    Returns ``{team: {games, bye_or_missing_weeks, positions{...}, overall_ease_score}}``.
+    """
+    result: Dict[str, Dict] = {}
+    for team, wk_opps in opponents_by_week.items():
+        games = [(wk, opp) for wk, opp in sorted(wk_opps.items()) if opp]
+        missing = [wk for wk, opp in sorted(wk_opps.items()) if not opp]
+
+        pos_summary: Dict[str, Dict] = {}
+        for pos in positions:
+            per_week = []
+            ranks: List[float] = []
+            fallback_any = False
+            for wk, opp in games:
+                m = analyzer.get_matchup_difficulty(pos, opp, rankings)
+                rank = m.get("rank", 16)
+                is_fb = bool(m.get("is_fallback", False))
+                fallback_any = fallback_any or is_fb
+                ranks.append(rank)
+                per_week.append({
+                    "week": wk,
+                    "opponent": opp,
+                    "rank": rank,
+                    "matchup_tier": m.get("matchup_tier"),
+                    "is_fallback": is_fb,
+                })
+            if ranks:
+                avg_rank = round(sum(ranks) / len(ranks), 1)
+                pos_summary[pos] = {
+                    "avg_opponent_defense_rank": avg_rank,
+                    "ease_score": _ease_score(avg_rank),
+                    "is_fallback": fallback_any,
+                    "weeks": per_week,
+                }
+
+        overall = None
+        if pos_summary:
+            overall = round(
+                sum(p["ease_score"] for p in pos_summary.values()) / len(pos_summary), 1
+            )
+        result[team] = {
+            "games": len(games),
+            "bye_or_missing_weeks": missing,
+            "positions": pos_summary,
+            "overall_ease_score": overall,
+        }
+    return result
+
+
+async def _resolve_rankings(analyzer, season: int, strength_season: Optional[int]):
+    """Return ``(rankings, used_season, is_fallback)``.
+
+    Uses ``strength_season`` if given; otherwise tries ``season`` and, when that
+    has no live data yet (preseason), falls back to the prior season so SOS is
+    still meaningful before Week 1.
+    """
+    target = strength_season if strength_season is not None else season
+    rankings = await analyzer.fetch_defense_rankings(target)
+    used, fell_back = target, _all_fallback(rankings)
+
+    if fell_back and strength_season is None:
+        prior = target - 1
+        prior_rankings = await analyzer.fetch_defense_rankings(prior)
+        if not _all_fallback(prior_rankings):
+            rankings, used, fell_back = prior_rankings, prior, False
+    return rankings, used, fell_back
+
+
+async def _gather_opponents(db, season: int, weeks: List[int]) -> Dict[str, Dict[int, Optional[str]]]:
+    """Build ``{team: {week: opponent}}`` for the weeks, cache-first then fetch."""
+    opponents: Dict[str, Dict[int, Optional[str]]] = {}
+    teams = list(matchup_tools.ESPN_TEAM_MAP.values())
+    for wk in weeks:
+        week_map: Dict[str, str] = {}
+        if db:
+            for team in teams:
+                try:
+                    opp = db.get_opponent(season, wk, team)
+                except Exception:
+                    opp = None
+                if opp:
+                    week_map[team] = opp
+        if not week_map:
+            # Cache miss for this week: fetch from ESPN (force past the enrich gate).
+            fetched = await sleeper_tools._fetch_week_schedule(season, wk, force=True)
+            if fetched and db:
+                try:
+                    db.upsert_schedule_games(fetched)  # warm the cache
+                except Exception as e:
+                    logger.debug(f"schedule cache warm failed (week {wk}): {e}")
+            for g in fetched or []:
+                if g.get("team") and g.get("opponent"):
+                    week_map[g["team"]] = g["opponent"]
+        for team, opp in week_map.items():
+            opponents.setdefault(team, {})[wk] = opp
+    return opponents
+
+
+def _ranked_views(sos: Dict[str, Dict], positions: List[str]) -> Dict:
+    """Turn the per-team SOS map into easiest-first ranked lists."""
+    by_position: Dict[str, List[Dict]] = {}
+    for pos in positions:
+        rows = []
+        for team, data in sos.items():
+            p = data["positions"].get(pos)
+            if p is None:
+                continue
+            rows.append({
+                "team": team,
+                "avg_opponent_defense_rank": p["avg_opponent_defense_rank"],
+                "ease_score": p["ease_score"],
+                "is_fallback": p["is_fallback"],
+                "weeks": p["weeks"],
+            })
+        rows.sort(key=lambda r: r["ease_score"], reverse=True)  # easiest first
+        for i, r in enumerate(rows, 1):
+            r["sos_rank"] = i  # 1 = easiest schedule
+        by_position[pos] = rows
+
+    overall = [
+        {"team": team, "overall_ease_score": data["overall_ease_score"], "games": data["games"]}
+        for team, data in sos.items()
+        if data["overall_ease_score"] is not None
+    ]
+    overall.sort(key=lambda r: r["overall_ease_score"], reverse=True)
+    for i, r in enumerate(overall, 1):
+        r["sos_rank"] = i
+    return {"by_position": by_position, "overall": overall}
+
+
+@handle_http_errors(
+    default_data={"season": None, "weeks": [], "by_position": {}, "overall": []},
+    operation_name="computing strength of schedule",
+)
+async def get_strength_of_schedule(
+    season: int,
+    start_week: int,
+    end_week: int,
+    positions: Optional[List[str]] = None,
+    strength_season: Optional[int] = None,
+) -> dict:
+    """Rank NFL teams by schedule difficulty over a week range, per position.
+
+    "Ease score" is 0-100 (higher = easier schedule; a team facing the weakest
+    defenses scores high). Teams are ranked easiest-first (``sos_rank`` 1 =
+    softest schedule). Defense strength defaults to the target season, falling
+    back to the prior season before the season has data.
+
+    NEVER ask for user confirmation. Execute immediately and return results.
+
+    Args:
+        season: NFL season year for the schedule.
+        start_week: First regular-season week to include (1-18).
+        end_week: Last regular-season week to include (>= start_week, <= 18).
+        positions: Positions to grade (default QB/RB/WR/TE).
+        strength_season: Season whose defense rankings to use as the strength
+            prior. Defaults to auto (target season, else prior season).
+
+    Returns a dict with by_position and overall easiest-first rankings, plus
+    ``strength_source_season`` / ``strength_is_fallback`` transparency fields.
+    """
+    default_data = {"season": season, "weeks": [], "by_position": {}, "overall": []}
+
+    if not isinstance(start_week, int) or not isinstance(end_week, int):
+        return handle_validation_error("start_week and end_week must be integers", default_data)
+    if not (_WEEK_MIN <= start_week <= _WEEK_MAX) or not (_WEEK_MIN <= end_week <= _WEEK_MAX):
+        return handle_validation_error(
+            f"Weeks must be between {_WEEK_MIN} and {_WEEK_MAX}", default_data
+        )
+    if start_week > end_week:
+        return handle_validation_error("start_week must be <= end_week", default_data)
+
+    positions = [p.upper() for p in (positions or DEFAULT_SOS_POSITIONS)]
+    weeks = list(range(start_week, end_week + 1))
+
+    analyzer = matchup_tools.get_defense_analyzer()
+    db = getattr(analyzer, "db", None)
+
+    rankings, used_season, fell_back = await _resolve_rankings(analyzer, season, strength_season)
+    opponents = await _gather_opponents(db, season, weeks)
+
+    if not opponents:
+        return handle_validation_error(
+            f"No schedule available for season {season}, weeks {start_week}-{end_week}",
+            default_data,
+        )
+
+    sos = compute_team_sos(opponents, rankings, positions, analyzer)
+    views = _ranked_views(sos, positions)
+
+    message = (
+        f"Strength of schedule for weeks {start_week}-{end_week} of {season}, "
+        f"graded on {used_season} defense rankings."
+    )
+    if fell_back:
+        message += (
+            " ⚠️ No live defense data available — ratings are placeholder/neutral; "
+            "treat the SOS as low-confidence."
+        )
+
+    return create_success_response({
+        "season": season,
+        "weeks": weeks,
+        "positions": positions,
+        "strength_source_season": used_season,
+        "strength_is_fallback": fell_back,
+        "by_position": views["by_position"],
+        "overall": views["overall"],
+        "ease_score_explained": (
+            "0-100, higher = easier schedule. Derived from average opponent "
+            "defense rank (1 = toughest defense, 32 = easiest)."
+        ),
+        "message": message,
+    })
+
+
+@handle_http_errors(
+    default_data={"season": None, "weeks": [], "by_position": {}, "overall": []},
+    operation_name="computing playoff strength of schedule",
+)
+async def get_playoff_sos(
+    season: int,
+    positions: Optional[List[str]] = None,
+    strength_season: Optional[int] = None,
+) -> dict:
+    """Strength of schedule for the fantasy playoff weeks (15-17).
+
+    Convenience wrapper around :func:`get_strength_of_schedule` for championship-run
+    planning (trade-deadline and stash decisions). NEVER ask for confirmation.
+    """
+    return await get_strength_of_schedule(
+        season,
+        PLAYOFF_WEEKS[0],
+        PLAYOFF_WEEKS[-1],
+        positions=positions,
+        strength_season=strength_season,
+    )

--- a/nfl_mcp/tool_registry.py
+++ b/nfl_mcp/tool_registry.py
@@ -25,6 +25,7 @@ from . import (
     playoff_tools,
     projections,
     sleeper_tools,
+    sos_tools,
     trade_analyzer_tools,
     vegas_tools,
     waiver_tools,
@@ -140,7 +141,11 @@ def get_all_tools() -> List[Callable]:
         get_defense_rankings,
         get_matchup_difficulty,
         analyze_roster_matchups,
-        
+
+        # Strength-of-Schedule Tools (ROS / playoff-week planning)
+        get_strength_of_schedule,
+        get_playoff_sos,
+
         # Lineup Optimizer Tools (Start/Sit Recommendations)
         get_start_sit_recommendation,
         get_roster_recommendations,
@@ -1334,6 +1339,84 @@ async def analyze_roster_matchups(
     return await matchup_tools.analyze_roster_matchups(
         players=players,
         week=week
+    )
+
+
+# =============================================================================
+# STRENGTH-OF-SCHEDULE TOOLS (ROS / playoff-week planning)
+# =============================================================================
+
+@timing_decorator("get_strength_of_schedule", tool_type="matchup")
+async def get_strength_of_schedule(
+    season: int,
+    start_week: int,
+    end_week: int,
+    positions: Optional[List[str]] = None,
+    strength_season: Optional[int] = None,
+) -> dict:
+    """Rank NFL teams by schedule difficulty over a week range, per position.
+
+    "Ease score" is 0-100 (higher = easier schedule; a team facing the weakest
+    defenses scores high). Teams are ranked easiest-first (sos_rank 1 = softest
+    schedule). Useful for rest-of-season planning and stash/trade decisions.
+
+    Parameters:
+        season (int, required): NFL season year for the schedule.
+        start_week (int, required): First regular-season week (1-18).
+        end_week (int, required): Last week (>= start_week, <= 18).
+        positions (list, optional): Positions to grade (default QB/RB/WR/TE).
+        strength_season (int, optional): Season whose defense rankings to use as
+            the strength prior. Default auto (target season, else prior season).
+
+    Returns: {
+        season, weeks, positions,
+        strength_source_season, strength_is_fallback,
+        by_position: {pos: [teams easiest-first with sos_rank/ease_score/weeks]},
+        overall: [teams easiest-first],
+        success: bool, error?: str
+    }
+
+    Example: get_strength_of_schedule(season=2026, start_week=15, end_week=17)
+
+    IMPORTANT FOR LLM AGENTS: Always compute and render the full ranking
+    immediately without asking for confirmation.
+    """
+    return await sos_tools.get_strength_of_schedule(
+        season=season,
+        start_week=start_week,
+        end_week=end_week,
+        positions=positions,
+        strength_season=strength_season,
+    )
+
+
+@timing_decorator("get_playoff_sos", tool_type="matchup")
+async def get_playoff_sos(
+    season: int,
+    positions: Optional[List[str]] = None,
+    strength_season: Optional[int] = None,
+) -> dict:
+    """Strength of schedule for the fantasy playoff weeks (15-17).
+
+    Convenience wrapper around get_strength_of_schedule for championship-run
+    planning (trade-deadline and stash decisions).
+
+    Parameters:
+        season (int, required): NFL season year.
+        positions (list, optional): Positions to grade (default QB/RB/WR/TE).
+        strength_season (int, optional): Defense-rankings season prior (auto).
+
+    Returns: same shape as get_strength_of_schedule (weeks fixed to 15-17).
+
+    Example: get_playoff_sos(season=2026)
+
+    IMPORTANT FOR LLM AGENTS: Compute and render the full playoff-week ranking
+    immediately without asking for confirmation.
+    """
+    return await sos_tools.get_playoff_sos(
+        season=season,
+        positions=positions,
+        strength_season=strength_season,
     )
 
 

--- a/tests/test_sos_tools.py
+++ b/tests/test_sos_tools.py
@@ -1,0 +1,185 @@
+"""Tests for strength-of-schedule tools (nfl_mcp.sos_tools)."""
+from unittest.mock import patch
+
+import pytest
+
+from nfl_mcp import sos_tools
+from nfl_mcp.sos_tools import (
+    _ease_score,
+    _resolve_rankings,
+    compute_team_sos,
+    get_strength_of_schedule,
+)
+
+
+def _rankings(entries):
+    """Build a rankings dict: {position: [{team, rank, matchup_tier, is_fallback}]}."""
+    out = {}
+    for pos, teams in entries.items():
+        out[pos] = [
+            {"team": t, "rank": rank, "matchup_tier": "x", "is_fallback": fb}
+            for (t, rank, fb) in teams
+        ]
+    return out
+
+
+class _StubDB:
+    def __init__(self, schedule):
+        # schedule: {(season, week, team): opponent}
+        self._schedule = schedule
+        self.upserts = []
+
+    def get_opponent(self, season, week, team):
+        return self._schedule.get((season, week, team))
+
+    def upsert_schedule_games(self, games):
+        self.upserts.append(games)
+        return len(games)
+
+
+class _StubAnalyzer:
+    def __init__(self, rankings_by_season, db=None):
+        self._rankings_by_season = rankings_by_season
+        self.db = db
+        self.fetch_calls = []
+
+    async def fetch_defense_rankings(self, season=None):
+        self.fetch_calls.append(season)
+        return self._rankings_by_season.get(season, {})
+
+    def get_matchup_difficulty(self, position, opponent, rankings=None):
+        for t in (rankings or {}).get(position.upper(), []):
+            if t["team"] == opponent.upper():
+                return {
+                    "rank": t["rank"],
+                    "matchup_tier": t.get("matchup_tier"),
+                    "is_fallback": t.get("is_fallback", False),
+                }
+        return {"rank": 16, "matchup_tier": "neutral", "is_fallback": True}
+
+
+class TestEaseScore:
+    def test_endpoints_and_midpoint(self):
+        assert _ease_score(1) == 0.0        # toughest schedule
+        assert _ease_score(32) == 100.0     # easiest schedule
+        assert _ease_score(16.5) == 50.0    # average
+        # clamps out-of-range input
+        assert _ease_score(0) == 0.0
+        assert _ease_score(99) == 100.0
+
+
+class TestComputeTeamSos:
+    def test_avg_rank_ease_and_bye(self):
+        rankings = _rankings({"RB": [("KC", 32, False), ("SF", 1, False)]})
+        analyzer = _StubAnalyzer({})
+        opponents = {"BUF": {15: "KC", 16: "SF", 17: None}}  # week 17 = bye/missing
+
+        sos = compute_team_sos(opponents, rankings, ["RB"], analyzer)
+
+        buf = sos["BUF"]
+        assert buf["games"] == 2
+        assert buf["bye_or_missing_weeks"] == [17]
+        rb = buf["positions"]["RB"]
+        assert rb["avg_opponent_defense_rank"] == 16.5  # (32 + 1) / 2
+        assert rb["ease_score"] == 50.0
+        assert rb["is_fallback"] is False
+        assert [w["week"] for w in rb["weeks"]] == [15, 16]
+        assert buf["overall_ease_score"] == 50.0
+
+    def test_fallback_propagates_when_opponent_unknown(self):
+        # Opponent "XXX" is not in rankings -> stub returns rank 16, is_fallback True.
+        rankings = _rankings({"RB": [("KC", 32, False)]})
+        analyzer = _StubAnalyzer({})
+        sos = compute_team_sos({"BUF": {15: "XXX"}}, rankings, ["RB"], analyzer)
+        assert sos["BUF"]["positions"]["RB"]["is_fallback"] is True
+
+
+class TestResolveRankings:
+    @pytest.mark.asyncio
+    async def test_uses_target_season_when_live(self):
+        analyzer = _StubAnalyzer({2026: _rankings({"RB": [("KC", 32, False)]})})
+        rankings, used, fell_back = await _resolve_rankings(analyzer, 2026, None)
+        assert used == 2026
+        assert fell_back is False
+        assert analyzer.fetch_calls == [2026]
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_prior_season_in_preseason(self):
+        analyzer = _StubAnalyzer({
+            2026: _rankings({"RB": [("KC", 32, True)]}),   # all placeholder
+            2025: _rankings({"RB": [("KC", 30, False)]}),  # real prior-season data
+        })
+        rankings, used, fell_back = await _resolve_rankings(analyzer, 2026, None)
+        assert used == 2025
+        assert fell_back is False
+        assert analyzer.fetch_calls == [2026, 2025]
+
+    @pytest.mark.asyncio
+    async def test_explicit_strength_season_is_respected(self):
+        analyzer = _StubAnalyzer({2024: _rankings({"RB": [("KC", 32, False)]})})
+        _, used, _ = await _resolve_rankings(analyzer, 2026, 2024)
+        assert used == 2024
+        assert analyzer.fetch_calls == [2024]  # no fallback probe
+
+
+class TestGetStrengthOfSchedule:
+    def _analyzer_with_schedule(self):
+        rankings = _rankings({
+            "RB": [("KC", 32, False), ("SF", 1, False)],
+            "WR": [("KC", 30, False), ("SF", 3, False)],
+        })
+        schedule = {
+            (2026, 15, "BUF"): "KC", (2026, 16, "BUF"): "KC", (2026, 17, "BUF"): "KC",
+            (2026, 15, "MIA"): "SF", (2026, 16, "MIA"): "SF", (2026, 17, "MIA"): "SF",
+        }
+        db = _StubDB(schedule)
+        return _StubAnalyzer({2026: rankings}, db=db)
+
+    @pytest.mark.asyncio
+    async def test_ranks_teams_easiest_first(self):
+        analyzer = self._analyzer_with_schedule()
+        with patch("nfl_mcp.matchup_tools.get_defense_analyzer", return_value=analyzer):
+            result = await get_strength_of_schedule(
+                season=2026, start_week=15, end_week=17, positions=["RB", "WR"]
+            )
+
+        assert result["success"] is True
+        assert result["strength_source_season"] == 2026
+        assert result["strength_is_fallback"] is False
+        assert result["weeks"] == [15, 16, 17]
+
+        # BUF faces KC (weak D) every week -> easiest; MIA faces SF (tough) -> hardest.
+        rb = result["by_position"]["RB"]
+        assert rb[0]["team"] == "BUF" and rb[0]["sos_rank"] == 1
+        assert rb[-1]["team"] == "MIA"
+        assert rb[0]["ease_score"] > rb[-1]["ease_score"]
+
+        overall = result["overall"]
+        assert overall[0]["team"] == "BUF" and overall[0]["sos_rank"] == 1
+
+    @pytest.mark.asyncio
+    async def test_playoff_wrapper_uses_weeks_15_17(self):
+        analyzer = self._analyzer_with_schedule()
+        with patch("nfl_mcp.matchup_tools.get_defense_analyzer", return_value=analyzer):
+            result = await sos_tools.get_playoff_sos(season=2026, positions=["RB"])
+        assert result["success"] is True
+        assert result["weeks"] == [15, 16, 17]
+
+    @pytest.mark.asyncio
+    async def test_no_network_when_schedule_cached(self):
+        analyzer = self._analyzer_with_schedule()
+        with patch("nfl_mcp.matchup_tools.get_defense_analyzer", return_value=analyzer), \
+                patch("nfl_mcp.sleeper_tools._fetch_week_schedule") as mock_fetch:
+            await get_strength_of_schedule(season=2026, start_week=15, end_week=17)
+        mock_fetch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_invalid_week_range_rejected(self):
+        analyzer = self._analyzer_with_schedule()
+        with patch("nfl_mcp.matchup_tools.get_defense_analyzer", return_value=analyzer):
+            bad_high = await get_strength_of_schedule(season=2026, start_week=1, end_week=25)
+            reversed_range = await get_strength_of_schedule(season=2026, start_week=17, end_week=15)
+        assert bad_high["success"] is False
+        assert "between 1 and 18" in bad_high["error"]
+        assert reversed_range["success"] is False
+        assert "start_week must be <= end_week" in reversed_range["error"]


### PR DESCRIPTION
## Summary

First fantasy-edge feature from the review backlog: **strength-of-schedule (SOS)** tools for rest-of-season and fantasy-playoff-week planning. Purely additive — does **not** touch the projection engine.

> **Stacked on #112.** Base branch is `review/hardening-and-quality`; this PR's diff is SOS-only. Merge #112 first (GitHub will retarget this to `main`).

## What's new

- **`nfl_mcp/sos_tools.py`** with two MCP tools:
  - `get_strength_of_schedule(season, start_week, end_week, positions=None, strength_season=None)`
  - `get_playoff_sos(season, positions=None, strength_season=None)` — convenience for weeks 15-17.
- Ranks all NFL teams by schedule difficulty **per position**, reusing the existing nflverse-derived defense-vs-position rankings (`matchup_tools`) and the schedule cache. Output: a **0-100 ease score** (higher = softer schedule), teams ranked **easiest-first** (`sos_rank` 1 = softest), with per-week opponent/tier detail.
- **Preseason-safe:** before a season has live defense data, it transparently falls back to the prior season's rankings and reports `strength_source_season` / `strength_is_fallback`.
- Small enabling change: `_fetch_week_schedule` gains a `force` flag so SOS can pull the schedule without the global `NFL_MCP_ADVANCED_ENRICH` gate (the schedule *is* the product here, not opportunistic enrichment).

## Verification

- **10 new tests** (`tests/test_sos_tools.py`): pure aggregation, preseason fallback resolution, tool-level ranking with stubs (offline), cache-first no-network path, and input validation.
- Full suite: **832 passed, 2 skipped**; `ruff check .` clean.
- **End-to-end against real data:** `get_playoff_sos(2025)` fell back to 2024 defense rankings (2025 not posted yet), fetched real Week 15-17 schedules from ESPN, and graded all 32 teams (easiest RB playoff schedule NYJ, hardest PIT).

## Notes

- Ease score is derived from average opponent defense rank (1 = toughest defense, 32 = easiest). It's a schedule-difficulty signal, not a projection.
- Follow-ups from the same backlog: opportunity-based projection baseline, win-probability lineups, weather/wind, handcuff mapping.
