### PR TITLE
feat: opportunity-based projection baseline (beats trailing-PPG on backtest)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Opportunity-based projection baseline** (`nfl_mcp/opportunity.py` + new MCP
+  tool `get_opportunity_projections`) — projects next-week PPR points from
+  recency-weighted trailing **volume** (targets/carries; QB pass attempts) ×
+  points-per-opportunity **shrunk toward a position prior**, instead of
+  rank-bucket PPG. Volume is stickier than points, so it orders players better.
+  **Backtested on real 2024 data (n=2505 player-weeks): MAE 5.78 → 5.70 (+1.4%),
+  Spearman 0.470 → 0.494** — beating both the trailing-PPG baseline *and* the
+  full matchup/usage multiplier stack, with the biggest gains at RB and TE. Wired
+  into the backtest harness (`evals/backtest`) as an `opportunity` model so it
+  stays measured. (Red-zone share isn't in the nflverse `player_stats` feed;
+  making this the default `project_player` baseline is the justified next step.)
 - **Weather / wind tool** (`nfl_mcp/weather_tools.py`) — new MCP tool
   `get_weather_forecast` reports per-game wind/precipitation/temperature from
   **Open-Meteo** (free, no API key) using static stadium coordinates + dome

--- a/evals/backtest/backtest.py
+++ b/evals/backtest/backtest.py
@@ -41,6 +41,7 @@ from collections import defaultdict
 from typing import Dict, List, Optional
 
 from nfl_mcp.matchup_tools import _get_matchup_tier
+from nfl_mcp.opportunity import project_opportunity
 
 # Import the LIVE constants so the backtest evaluates production behaviour.
 from nfl_mcp.projections import _MATCHUP_TIER_DEV, _usage_mult, matchup_multiplier
@@ -130,10 +131,16 @@ def build_samples(
         tier_dev = _MATCHUP_TIER_DEV.get(tier, 0.0)        # raw ±dev for sweeps
         u_mult = _usage_mult(None, _touch_trend(prior))
 
+        # Opportunity-based baseline (volume × shrunk efficiency), leak-free.
+        opp = project_opportunity(prior, r["position"])
+        if opp is None:
+            opp = trailing
+
         samples.append({
             "position": r["position"],
             "actual": r["ppr"],
             "base": trailing,
+            "opportunity": opp,
             "matchup": trailing * m_mult,
             "usage": trailing * u_mult,
             "full": trailing * m_mult * u_mult,
@@ -158,10 +165,10 @@ def run_backtest(
 
     samples = build_samples(records, start_week, min_prior, min_trailing, positions)
 
-    models = ["base", "matchup", "usage", "full"]
+    models = ["base", "opportunity", "matchup", "usage", "full"]
     results = {m: evaluate(*_series(samples, m)) for m in models}
 
-    # Per-position breakdown for base vs full.
+    # Per-position breakdown: base (trailing PPG) vs opportunity vs full.
     per_pos: Dict[str, Dict] = {}
     for pos in ("QB", "RB", "WR", "TE"):
         sub = [s for s in samples if s["position"] == pos]
@@ -170,6 +177,7 @@ def run_backtest(
         per_pos[pos] = {
             "n": len(sub),
             "base": evaluate(*_series(sub, "base")),
+            "opportunity": evaluate(*_series(sub, "opportunity")),
             "full": evaluate(*_series(sub, "full")),
         }
 
@@ -229,8 +237,8 @@ def print_report(res: Dict) -> None:
     print(f"PROJECTION BACKTEST — seasons {res['seasons']}, weeks {res['start_week']}+, "
           f"trailing≥{res['min_trailing']} pts, n={res['n_samples']} player-weeks")
     print("=" * 78)
-    print("\nModels (base = trailing PPG; then × live multipliers):")
-    for name in ("base", "matchup", "usage", "full"):
+    print("\nModels (base = trailing PPG; opportunity = volume×shrunk-efficiency):")
+    for name in ("base", "opportunity", "matchup", "usage", "full"):
         print(_fmt_row(name, res["models"][name]))
 
     b, f = res["models"]["base"]["mae"], res["models"]["full"]["mae"]
@@ -238,11 +246,18 @@ def print_report(res: Dict) -> None:
     verdict = ("adjustments HELP" if f < b else "adjustments do NOT help — revisit")
     print(f"\n  => full vs base: MAE {b} -> {f} ({delta:+.1f}%)  [{verdict}]")
 
-    print("\nPer position (base MAE -> full MAE):")
+    o = res["models"]["opportunity"]
+    bs, os_ = res["models"]["base"]["spearman"], o["spearman"]
+    od = (b - o["mae"]) / b * 100 if b else 0
+    ov = ("opportunity HELPS" if o["mae"] < b else "opportunity does NOT help — revisit")
+    print(f"  => opportunity vs base: MAE {b} -> {o['mae']} ({od:+.1f}%), "
+          f"Spearman {bs} -> {os_}  [{ov}]")
+
+    print("\nPer position (base -> opportunity, MAE & Spearman):")
     for pos, d in res["per_position"].items():
-        bm, fm = d["base"]["mae"], d["full"]["mae"]
-        print(f"  {pos}: n={d['n']:<4} {bm} -> {fm} ({(bm-fm)/bm*100:+.1f}%)  "
-              f"Spearman {d['base']['spearman']} -> {d['full']['spearman']}")
+        bm, om = d["base"]["mae"], d["opportunity"]["mae"]
+        print(f"  {pos}: n={d['n']:<4} MAE {bm} -> {om} ({(bm-om)/bm*100:+.1f}%)  "
+              f"Spearman {d['base']['spearman']} -> {d['opportunity']['spearman']}")
 
     print("\nMatchup-strength tuning (effective_mult = 1 + s·(mult−1)):")
     for t in res["tuning"]["sweep"]:

--- a/evals/backtest/data.py
+++ b/evals/backtest/data.py
@@ -71,10 +71,8 @@ def load_season(season: int, use_cache: bool = True) -> List[Dict]:
         pid = row.get("player_id")
         if not (opp and wk and pid):
             continue
-        touches = (
-            _to_float(row.get("targets"))
-            + _to_float(row.get("carries") or row.get("rushing_attempts"))
-        )
+        targets = _to_float(row.get("targets"))
+        carries = _to_float(row.get("carries") or row.get("rushing_attempts"))
         records.append({
             "player_id": pid,
             "player": row.get("player_display_name") or row.get("player_name"),
@@ -84,7 +82,19 @@ def load_season(season: int, use_cache: bool = True) -> List[Dict]:
             "season": int(season),
             "week": int(wk),
             "ppr": _to_float(row.get("fantasy_points_ppr")),
-            "touches": touches,
+            "touches": targets + carries,
+            # Opportunity components (for the opportunity-based projection).
+            "targets": targets,
+            "carries": carries,
+            "attempts": _to_float(row.get("attempts")),
+            "receptions": _to_float(row.get("receptions")),
+            "receiving_yards": _to_float(row.get("receiving_yards")),
+            "receiving_tds": _to_float(row.get("receiving_tds")),
+            "rushing_yards": _to_float(row.get("rushing_yards")),
+            "rushing_tds": _to_float(row.get("rushing_tds")),
+            "passing_yards": _to_float(row.get("passing_yards")),
+            "passing_tds": _to_float(row.get("passing_tds")),
+            "interceptions": _to_float(row.get("interceptions")),
         })
     logger.info("Loaded %d REG records for %s", len(records), season)
     return records

--- a/nfl_mcp/opportunity.py
+++ b/nfl_mcp/opportunity.py
@@ -1,0 +1,112 @@
+"""Opportunity-based weekly projection.
+
+The projection lever isn't more multipliers — the backtest shows those barely
+move accuracy — it's a better *baseline*. Volume (targets, carries, pass
+attempts) is far more stable week to week than fantasy points, whose variance is
+dominated by touchdowns and yardage spikes. So instead of projecting a player's
+trailing points, we project their trailing *opportunity* and convert it to points
+via an efficiency rate that is shrunk toward a position prior (so a small sample
+of hot/cold weeks doesn't dominate).
+
+    expected_points = exp_targets · ppt + exp_carries · ppc          (RB/WR/TE)
+    expected_points = exp_attempts · ppa + exp_carries · ppc         (QB)
+
+where exp_* are recency-weighted trailing volumes and pp* are the player's own
+points-per-opportunity shrunk toward a position prior. All PPR.
+
+This module is pure and unit-testable; whether it becomes the live baseline is
+decided by the backtest (see ``evals/backtest``), not asserted.
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+# Standard PPR scoring weights (match nflverse `fantasy_points_ppr`).
+PASS_YD, PASS_TD, INT = 0.04, 4.0, -2.0
+RUSH_YD, RUSH_TD = 0.1, 6.0
+REC, REC_YD, REC_TD = 1.0, 0.1, 6.0
+
+# Position priors: PPR points per opportunity (per target / carry / pass attempt).
+_PRIORS: Dict[str, Dict[str, float]] = {
+    "WR": {"ppt": 1.55, "ppc": 0.50},
+    "TE": {"ppt": 1.35, "ppc": 0.50},
+    "RB": {"ppt": 1.45, "ppc": 0.62},
+    "QB": {"ppa": 0.45, "ppc": 0.75},
+}
+# Shrinkage strength, in opportunity units: a player needs ~this many targets/
+# carries/attempts before their own efficiency outweighs the position prior.
+_K_TARGETS, _K_CARRIES, _K_ATTEMPTS = 20.0, 25.0, 60.0
+
+DEFAULT_LOOKBACK = 6
+OPPORTUNITY_POSITIONS = ("QB", "RB", "WR", "TE")
+
+
+def rec_points(g: Dict) -> float:
+    return (g.get("receptions", 0.0) * REC
+            + g.get("receiving_yards", 0.0) * REC_YD
+            + g.get("receiving_tds", 0.0) * REC_TD)
+
+
+def rush_points(g: Dict) -> float:
+    return g.get("rushing_yards", 0.0) * RUSH_YD + g.get("rushing_tds", 0.0) * RUSH_TD
+
+
+def pass_points(g: Dict) -> float:
+    return (g.get("passing_yards", 0.0) * PASS_YD
+            + g.get("passing_tds", 0.0) * PASS_TD
+            + g.get("interceptions", 0.0) * INT)
+
+
+def _weighted_mean(values: List[float], weights: List[float]) -> float:
+    tw = sum(weights)
+    return sum(v * w for v, w in zip(weights, values, strict=False)) / tw if tw else 0.0
+
+
+def _shrunk_rate(total_points: float, total_volume: float, prior: float, k: float) -> float:
+    """Player's points-per-opportunity, shrunk toward the position prior."""
+    return (total_points + k * prior) / (total_volume + k)
+
+
+def project_opportunity(
+    prior_games: List[Dict],
+    position: str,
+    lookback: int = DEFAULT_LOOKBACK,
+) -> Optional[float]:
+    """Expected PPR points for the next game from trailing opportunity.
+
+    Args:
+        prior_games: the player's earlier weekly stat dicts (each with targets,
+            carries, attempts, receptions, *_yards, *_tds, interceptions, week).
+            MUST contain only games before the one being predicted (leak-free).
+        position: QB/RB/WR/TE.
+        lookback: how many most-recent games to weight (recency-weighted linearly).
+
+    Returns expected points, or None if the position/data can't be projected.
+    """
+    pos = position.upper()
+    priors = _PRIORS.get(pos)
+    if priors is None or not prior_games:
+        return None
+
+    games = sorted(prior_games, key=lambda g: g.get("week", 0))[-lookback:]
+    n = len(games)
+    # Recency weights: oldest .. newest -> 1 .. n.
+    weights = list(range(1, n + 1))
+
+    exp_carries = _weighted_mean([g.get("carries", 0.0) for g in games], weights)
+    tot_carries = sum(g.get("carries", 0.0) for g in games)
+    tot_rush_pts = sum(rush_points(g) for g in games)
+    ppc = _shrunk_rate(tot_rush_pts, tot_carries, priors["ppc"], _K_CARRIES)
+
+    if pos == "QB":
+        exp_attempts = _weighted_mean([g.get("attempts", 0.0) for g in games], weights)
+        tot_attempts = sum(g.get("attempts", 0.0) for g in games)
+        tot_pass_pts = sum(pass_points(g) for g in games)
+        ppa = _shrunk_rate(tot_pass_pts, tot_attempts, priors["ppa"], _K_ATTEMPTS)
+        return max(0.0, exp_attempts * ppa + exp_carries * ppc)
+
+    exp_targets = _weighted_mean([g.get("targets", 0.0) for g in games], weights)
+    tot_targets = sum(g.get("targets", 0.0) for g in games)
+    tot_rec_pts = sum(rec_points(g) for g in games)
+    ppt = _shrunk_rate(tot_rec_pts, tot_targets, priors["ppt"], _K_TARGETS)
+    return max(0.0, exp_targets * ppt + exp_carries * ppc)

--- a/nfl_mcp/opportunity_tools.py
+++ b/nfl_mcp/opportunity_tools.py
@@ -1,0 +1,180 @@
+"""Opportunity-based projection tool.
+
+Fetches a season's weekly player logs from nflverse and projects each player's
+next-week PPR points from trailing *opportunity* (volume × shrunk efficiency)
+via :mod:`nfl_mcp.opportunity`. Backtested to beat trailing-PPG on both MAE and
+rank correlation (see ``evals/backtest``). Key-free.
+"""
+from __future__ import annotations
+
+import csv
+import logging
+from io import StringIO
+from typing import Dict, List, Optional
+
+from . import opportunity
+from .config import LONG_TIMEOUT, create_http_client
+from .errors import create_success_response, handle_http_errors, handle_validation_error
+from .matchup_tools import _NFLVERSE_TEAM_FIX, NFLVERSE_PLAYER_STATS_URL
+
+logger = logging.getLogger(__name__)
+
+_STAT_FIELDS = (
+    "targets", "carries", "attempts", "receptions",
+    "receiving_yards", "receiving_tds", "rushing_yards", "rushing_tds",
+    "passing_yards", "passing_tds", "interceptions",
+)
+_logs_cache: Dict[int, Dict[str, Dict]] = {}
+
+
+def _to_float(v) -> float:
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def parse_game_logs(csv_text: str) -> Dict[str, Dict]:
+    """Parse nflverse weekly CSV into ``{player_id: {name, position, team, games[...]}}``.
+
+    Only regular-season QB/RB/WR/TE rows are kept. Pure/testable.
+    """
+    logs: Dict[str, Dict] = {}
+    for row in csv.DictReader(StringIO(csv_text)):
+        if (row.get("season_type") or "").upper() != "REG":
+            continue
+        pos = (row.get("position") or row.get("position_group") or "").upper()
+        if pos not in opportunity.OPPORTUNITY_POSITIONS:
+            continue
+        pid = row.get("player_id")
+        wk = row.get("week")
+        if not pid or not wk:
+            continue
+        team = (row.get("recent_team") or row.get("team") or "").upper()
+        entry = logs.setdefault(pid, {
+            "player_id": pid,
+            "name": row.get("player_display_name") or row.get("player_name"),
+            "position": pos,
+            "team": _NFLVERSE_TEAM_FIX.get(team, team),
+            "games": [],
+        })
+        game = {"week": int(wk)}
+        for f in _STAT_FIELDS:
+            game[f] = _to_float(row.get(f))
+        entry["games"].append(game)
+    return logs
+
+
+async def _fetch_game_logs(season: int) -> Dict[str, Dict]:
+    """Fetch + parse a season's game logs (cached per season). ``{}`` if unavailable."""
+    if season in _logs_cache:
+        return _logs_cache[season]
+    url = NFLVERSE_PLAYER_STATS_URL.format(season=season)
+    try:
+        async with create_http_client(timeout=LONG_TIMEOUT) as client:
+            resp = await client.get(url)
+            if resp.status_code == 404:
+                return {}
+            resp.raise_for_status()
+            logs = parse_game_logs(resp.text)
+    except Exception as e:
+        logger.debug(f"opportunity game-log fetch failed for {season}: {e}")
+        return {}
+    _logs_cache[season] = logs
+    return logs
+
+
+def _match(entry: Dict, query: str) -> bool:
+    q = query.strip().lower()
+    return q == entry["player_id"].lower() or q in (entry["name"] or "").lower()
+
+
+def _project_entry(entry: Dict, week: int, lookback: int, min_games: int) -> Optional[Dict]:
+    """Project one player from games before `week`. None if too few prior games."""
+    prior = [g for g in entry["games"] if g["week"] < week]
+    if len(prior) < min_games:
+        return None
+    proj = opportunity.project_opportunity(prior, entry["position"], lookback=lookback)
+    if proj is None:
+        return None
+    window = sorted(prior, key=lambda g: g["week"])[-lookback:]
+    exp_targets = round(sum(g["targets"] for g in window) / len(window), 1)
+    exp_carries = round(sum(g["carries"] for g in window) / len(window), 1)
+    return {
+        "player_id": entry["player_id"],
+        "name": entry["name"],
+        "position": entry["position"],
+        "team": entry["team"],
+        "projected_ppr": round(proj, 1),
+        "games_used": len(window),
+        "exp_targets": exp_targets,
+        "exp_carries": exp_carries,
+    }
+
+
+@handle_http_errors(
+    default_data={"season": None, "week": None, "projections": []},
+    operation_name="computing opportunity projections",
+)
+async def get_opportunity_projections(
+    season: int,
+    week: int,
+    players: Optional[List[str]] = None,
+    lookback: int = opportunity.DEFAULT_LOOKBACK,
+    min_games: int = 2,
+    top_n: int = 50,
+) -> dict:
+    """Opportunity-based PPR projections for `week` from trailing volume.
+
+    Projects each player's next-week points from recency-weighted trailing
+    targets/carries (QB: pass attempts) × their points-per-opportunity shrunk
+    toward a position prior — a baseline that beats trailing-PPG on the backtest.
+    Uses only games *before* `week`. NEVER ask for confirmation.
+
+    Args:
+        season: NFL season year.
+        week: Week to project (uses weeks < `week` as history; must be > 1).
+        players: Optional names or player_ids to project. If omitted, returns the
+            top_n projected players (useful for waiver/streamer discovery).
+        lookback: Trailing games to weight (default 6).
+        min_games: Minimum prior games required to project a player (default 2).
+        top_n: Cap when `players` is omitted (default 50).
+
+    Returns a dict with `projections` (highest-first), each carrying the expected
+    volume and projected PPR points.
+    """
+    default_data = {"season": season, "week": week, "projections": []}
+    if not isinstance(week, int) or week < 2:
+        return handle_validation_error("week must be an integer >= 2 (needs prior weeks)", default_data)
+
+    logs = await _fetch_game_logs(season)
+    if not logs:
+        return handle_validation_error(
+            f"No nflverse game logs available for season {season}", default_data
+        )
+
+    if players:
+        entries = [e for e in logs.values() if any(_match(e, q) for q in players)]
+    else:
+        entries = list(logs.values())
+
+    projections = [p for e in entries if (p := _project_entry(e, week, lookback, min_games))]
+    projections.sort(key=lambda p: p["projected_ppr"], reverse=True)
+    if not players and top_n:
+        projections = projections[:top_n]
+
+    return create_success_response({
+        "season": season,
+        "week": week,
+        "lookback": lookback,
+        "count": len(projections),
+        "projections": projections,
+        "method": (
+            "opportunity baseline: recency-weighted trailing volume × "
+            "position-shrunk points-per-opportunity (PPR). Beats trailing-PPG on backtest."
+        ),
+        "message": (
+            f"Opportunity projections for week {week} of {season} "
+            f"({len(projections)} player(s))."
+        ),
+    })

--- a/nfl_mcp/tool_registry.py
+++ b/nfl_mcp/tool_registry.py
@@ -21,6 +21,7 @@ from . import (
     matchup_tools,
     nfl_tools,
     opponent_analysis_tools,
+    opportunity_tools,
     player_values,
     playoff_tools,
     projections,
@@ -135,6 +136,7 @@ def get_all_tools() -> List[Callable]:
         # Projection Tools (transparent weekly projections)
         project_player,
         project_players,
+        get_opportunity_projections,
 
         # Opponent Analysis Tools
         analyze_opponent,
@@ -1151,6 +1153,54 @@ async def project_players(
         return {"projections": [], "total": 0, "success": False, "error": "No players provided"}
     return await projections.project_players(
         players=players, scoring=scoring, superflex=superflex, num_teams=num_teams, db=get_db(),
+    )
+
+
+@timing_decorator("get_opportunity_projections", tool_type="projection")
+async def get_opportunity_projections(
+    season: int,
+    week: int,
+    players: Optional[List[str]] = None,
+    lookback: int = 6,
+    min_games: int = 2,
+    top_n: int = 50,
+) -> dict:
+    """Opportunity-based PPR projections from trailing volume (beats trailing-PPG).
+
+    Projects each player's next-week points from recency-weighted trailing
+    targets/carries (QB: pass attempts) × their points-per-opportunity shrunk
+    toward a position prior. Volume is stickier than points, so this orders
+    players better for start/sit (validated on the backtest: MAE and Spearman
+    both improve vs a trailing-PPG baseline). Key-free (nflverse).
+
+    Parameters:
+        season (int, required): NFL season year.
+        week (int, required): Week to project (>= 2; uses weeks < week as history).
+        players (list, optional): Names or player_ids to project; omit for the
+            top_n projected players (waiver/streamer discovery).
+        lookback (int, optional): Trailing games to weight (default 6).
+        min_games (int, optional): Min prior games to project a player (default 2).
+        top_n (int, optional): Cap when players is omitted (default 50).
+
+    Returns: {
+        season, week, lookback, count,
+        projections: [{player_id, name, position, team, projected_ppr,
+                       exp_targets, exp_carries, games_used}] (highest-first),
+        success: bool, error?: str
+    }
+
+    Example: get_opportunity_projections(season=2025, week=10, players=["Puka Nacua"])
+
+    IMPORTANT FOR LLM AGENTS: Compute and render the projections immediately
+    without asking for confirmation.
+    """
+    return await opportunity_tools.get_opportunity_projections(
+        season=season,
+        week=week,
+        players=players,
+        lookback=lookback,
+        min_games=min_games,
+        top_n=top_n,
     )
 
 

--- a/tests/test_opportunity.py
+++ b/tests/test_opportunity.py
@@ -1,0 +1,125 @@
+"""Tests for the opportunity-based projection library and tool."""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nfl_mcp.opportunity import (
+    _weighted_mean,
+    project_opportunity,
+    rec_points,
+    rush_points,
+)
+from nfl_mcp.opportunity_tools import get_opportunity_projections, parse_game_logs
+
+
+def _wr_game(week, targets, rec, rec_yds, rec_td=0.0, carries=0.0):
+    return {
+        "week": week, "targets": targets, "receptions": rec,
+        "receiving_yards": rec_yds, "receiving_tds": rec_td, "carries": carries,
+    }
+
+
+class TestScoring:
+    def test_rec_and_rush_points(self):
+        # 6 rec + 80 yds + 1 TD = 6 + 8 + 6 = 20 (PPR)
+        assert rec_points({"receptions": 6, "receiving_yards": 80, "receiving_tds": 1}) == 20.0
+        # 50 yds + 1 TD = 5 + 6 = 11
+        assert rush_points({"rushing_yards": 50, "rushing_tds": 1}) == 11.0
+
+
+class TestWeightedMean:
+    def test_recency_weights_favor_recent(self):
+        # targets 2,4,6,8 with weights 1,2,3,4 -> 60/10 = 6.0 (> flat mean 5.0)
+        assert _weighted_mean([2, 4, 6, 8], [1, 2, 3, 4]) == 6.0
+
+
+class TestProjectOpportunity:
+    def test_wr_projection_matches_model(self):
+        games = [_wr_game(w, targets=8, rec=6, rec_yds=80) for w in range(1, 5)]
+        # rec_pts/gm = 6 + 8 = 14; ppt = (56 + 20*1.55)/(32+20) = 87/52 = 1.673
+        # exp_targets = 8 -> 8 * 1.673 = 13.38
+        proj = project_opportunity(games, "WR")
+        assert proj == pytest.approx(13.38, abs=0.1)
+
+    def test_shrinkage_pulls_small_sample_toward_prior(self):
+        # One monster game (huge efficiency) should be shrunk toward the prior,
+        # not projected at face value.
+        hot = [_wr_game(1, targets=2, rec=2, rec_yds=100, rec_td=2)]  # 2+10+12 = 24 pts on 2 tgt
+        proj = project_opportunity(hot, "WR")
+        raw_ppt = 24 / 2  # 12 pts/target if we trusted the sample fully
+        assert proj is not None
+        assert proj < 2 * raw_ppt * 0.5  # heavily regressed, nowhere near 2*12
+
+    def test_qb_uses_attempts(self):
+        games = [
+            {"week": w, "attempts": 35, "passing_yards": 280, "passing_tds": 2,
+             "interceptions": 1, "carries": 3, "rushing_yards": 15, "rushing_tds": 0}
+            for w in range(1, 5)
+        ]
+        proj = project_opportunity(games, "QB")
+        assert proj == pytest.approx(18.77, abs=0.2)
+
+    def test_unknown_position_and_empty(self):
+        assert project_opportunity([_wr_game(1, 5, 4, 50)], "K") is None
+        assert project_opportunity([], "WR") is None
+
+
+class TestParseGameLogs:
+    def test_groups_and_filters(self):
+        csv_text = (
+            "season_type,position,player_id,player_display_name,recent_team,week,"
+            "targets,carries,receptions,receiving_yards,receiving_tds\n"
+            "REG,WR,a1,Alpha,BUF,1,9,0,6,80,0\n"
+            "REG,WR,a1,Alpha,BUF,2,11,0,8,110,1\n"
+            "POST,WR,a1,Alpha,BUF,3,20,0,15,200,3\n"   # dropped: not REG
+            "REG,K,k1,Kicker,BUF,1,0,0,0,0,0\n"        # dropped: position
+        )
+        logs = parse_game_logs(csv_text)
+        assert set(logs) == {"a1"}
+        assert logs["a1"]["name"] == "Alpha"
+        assert len(logs["a1"]["games"]) == 2          # POST dropped
+        assert logs["a1"]["games"][0]["targets"] == 9.0
+
+
+class TestGetOpportunityProjections:
+    def _logs(self):
+        return {
+            "a1": {"player_id": "a1", "name": "Alpha WR", "position": "WR", "team": "BUF",
+                   "games": [_wr_game(w, targets=10, rec=7, rec_yds=95) for w in range(1, 6)]},
+            "b1": {"player_id": "b1", "name": "Bravo WR", "position": "WR", "team": "MIA",
+                   "games": [_wr_game(w, targets=3, rec=2, rec_yds=22) for w in range(1, 6)]},
+        }
+
+    @pytest.mark.asyncio
+    async def test_ranks_highest_first(self):
+        with patch("nfl_mcp.opportunity_tools._fetch_game_logs",
+                   new=AsyncMock(return_value=self._logs())):
+            result = await get_opportunity_projections(season=2025, week=6)
+        assert result["success"] is True
+        assert result["count"] == 2
+        projs = result["projections"]
+        assert projs[0]["name"] == "Alpha WR"     # more volume -> higher projection
+        assert projs[0]["projected_ppr"] > projs[1]["projected_ppr"]
+        assert projs[0]["exp_targets"] == 10.0
+
+    @pytest.mark.asyncio
+    async def test_player_filter(self):
+        with patch("nfl_mcp.opportunity_tools._fetch_game_logs",
+                   new=AsyncMock(return_value=self._logs())):
+            result = await get_opportunity_projections(season=2025, week=6, players=["Bravo"])
+        assert result["count"] == 1
+        assert result["projections"][0]["name"] == "Bravo WR"
+
+    @pytest.mark.asyncio
+    async def test_week_1_rejected(self):
+        result = await get_opportunity_projections(season=2025, week=1)
+        assert result["success"] is False
+        assert "week must be" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_empty_logs_errors(self):
+        with patch("nfl_mcp.opportunity_tools._fetch_game_logs",
+                   new=AsyncMock(return_value={})):
+            result = await get_opportunity_projections(season=1999, week=6)
+        assert result["success"] is False
+        assert "No nflverse game logs" in result["error"]


### PR DESCRIPTION
## Summary

The projection lever isn't more multipliers — the backtest has long shown those barely move accuracy — it's a better **baseline**. This adds an **opportunity-based projection**: project a player's next-week points from recency-weighted trailing **volume** (targets/carries; QB pass attempts) × their points-per-opportunity **shrunk toward a position prior**, instead of rank-bucket PPG. Volume is stickier than points, so it orders players better for start/sit.

## Backtest result (the point of this PR)

Wired into the existing harness (`evals/backtest`) as an `opportunity` model and measured on **real 2024 data (n = 2505 player-weeks)**:

| Model | MAE | Spearman |
|---|---|---|
| base (trailing PPG) | 5.783 | 0.4705 |
| **opportunity** | **5.704  (+1.4%)** | **0.4941  (+0.024)** |
| full (matchup × usage multipliers) | 5.767 | 0.4776 |

The opportunity baseline beats **both** trailing-PPG **and** the full multiplier stack, on MAE and on the rank correlation that actually drives start/sit. Biggest gains at **RB** (MAE +2.4%) and **TE** (Spearman 0.315 → 0.350).

## What's in it

- **`nfl_mcp/opportunity.py`** — pure, unit-tested model: `project_opportunity(prior_games, position, lookback=6)`. Recency-weighted volume × shrunk points-per-opportunity (shrinkage regresses small-sample efficiency toward a position prior).
- **`get_opportunity_projections(season, week, players=None, …)`** — MCP tool that fetches live nflverse game logs and projects (key-free). Returns highest-first with expected volume.
- **Backtest integration** — `evals/backtest` now reports `opportunity` vs `base` so the claim stays honest and re-checkable.

## Verification

- **11 tests** (scoring, recency weighting, shrinkage, QB path, CSV parse, tool ranking/filter/validation).
- `ruff check .` clean; full suite **866 passed, 2 skipped**.
- **Live:** 2024 W10 top projections surface the elite volume producers (Lamar Jackson, CeeDee Lamb @ 11.2 tgt, Saquon Barkley @ 18.5 car); Bijan Robinson 20.6.

## Notes / follow-ups

- Red-zone share isn't in the nflverse `player_stats` feed — a future play-by-play integration could add it.
- **Making this `project_player`'s default baseline** (replacing rank-bucket PPG in the live engine) is the justified next step now that it's measured to help; kept as a standalone tool in this PR to keep the change reviewable.
