### PR TITLE
feat: use opportunity baseline as default in project_player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   contracts watchdog under `evals/`.
 
 ### Changed
+- **`project_player`/`project_players` default to the opportunity baseline** when
+  `season` + `week` are supplied — the backtested opportunity projection
+  (trailing nflverse volume × shrunk efficiency) replaces rank-bucket PPG as the
+  base. The usage multiplier is skipped in that path (volume trend is already in
+  the base) while matchup / environment / injury still apply. Players without
+  enough nflverse history (rookies, preseason, K/DST) and calls that omit
+  season/week transparently fall back to the rank-bucket baseline — fully
+  backward compatible. The breakdown now reports `base_source`. This wires the
+  measured EV win (PR #116) into the tools start/sit and lineups already use.
 - **Docs split** — the README was slimmed from a ~58 KB monolith to a concise,
   feature-oriented overview (~140 lines) with a complete grouped catalog of all
   registered tools (including the new SOS / streaming / weather tools). Setup,

--- a/nfl_mcp/opportunity_tools.py
+++ b/nfl_mcp/opportunity_tools.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import csv
 import logging
+import re
 from io import StringIO
 from typing import Dict, List, Optional
 
@@ -87,6 +88,44 @@ async def _fetch_game_logs(season: int) -> Dict[str, Dict]:
 def _match(entry: Dict, query: str) -> bool:
     q = query.strip().lower()
     return q == entry["player_id"].lower() or q in (entry["name"] or "").lower()
+
+
+_SUFFIX_RE = re.compile(r"\b(jr|sr|ii|iii|iv|v)\b")
+
+
+def norm_name(s: Optional[str]) -> str:
+    """Normalize a player name for cross-source matching (nflverse ↔ league)."""
+    s = (s or "").lower()
+    s = re.sub(r"[.',]", "", s)
+    s = _SUFFIX_RE.sub("", s)
+    return " ".join(s.split())
+
+
+def build_name_index(logs: Dict[str, Dict]) -> Dict[str, Dict]:
+    """Index game logs by normalized player name for O(1) projection lookup."""
+    return {norm_name(e["name"]): e for e in logs.values()}
+
+
+def opportunity_base_for(
+    name_index: Dict[str, Dict],
+    name: str,
+    position: str,
+    week: int,
+    lookback: int = opportunity.DEFAULT_LOOKBACK,
+    min_games: int = 2,
+) -> Optional[float]:
+    """Opportunity projection for a player (by name) usable as a projection base.
+
+    Returns None when the player isn't found, the position isn't a skill/QB
+    position, or there aren't enough prior games — callers then fall back.
+    """
+    entry = name_index.get(norm_name(name))
+    if not entry or (position or "").upper() not in opportunity.OPPORTUNITY_POSITIONS:
+        return None
+    prior = [g for g in entry["games"] if g["week"] < week]
+    if len(prior) < min_games:
+        return None
+    return opportunity.project_opportunity(prior, position, lookback=lookback)
 
 
 def _project_entry(entry: Dict, week: int, lookback: int, min_games: int) -> Optional[Dict]:

--- a/nfl_mcp/projections.py
+++ b/nfl_mcp/projections.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 from typing import Dict, List, Optional
 
+from . import opportunity_tools
 from .errors import ErrorType, create_error_response, create_success_response, handle_http_errors
 from .matchup_tools import get_defense_analyzer
 from .player_values import get_values_service, scoring_to_ppr
@@ -118,7 +119,10 @@ class ProjectionEngine:
         self.defense = get_defense_analyzer()
         self.vegas = get_vegas_analyzer()
 
-    def _project_one(self, player: Dict, values_index: Dict, rankings: Dict, lines: Dict) -> Dict:
+    def _project_one(
+        self, player: Dict, values_index: Dict, rankings: Dict, lines: Dict,
+        opp_index: Optional[Dict] = None, week: Optional[int] = None,
+    ) -> Dict:
         name = player.get("name") or player.get("player_name")
         position = (player.get("position") or "").upper()
         team = (player.get("team") or "").upper()
@@ -127,10 +131,18 @@ class ProjectionEngine:
         usage = player.get("usage") or {}
         injury = player.get("injury") or {}
 
-        # 1) Baseline from positional rank (real market data when available)
+        # 1) Baseline. Prefer the opportunity-based projection (backtested to beat
+        #    rank-bucket PPG) when we have this player's trailing nflverse volume;
+        #    otherwise fall back to the positional-rank baseline.
         market = self.values.lookup(values_index, player_id=player_id, name=name, position=position)
         pos_rank = (market or {}).get("position_rank")
         base = base_ppg(position, pos_rank)
+        base_source = "rank_bucket"
+        if opp_index and week and name:
+            opp_base = opportunity_tools.opportunity_base_for(opp_index, name, position, week)
+            if opp_base is not None:
+                base = round(opp_base, 1)
+                base_source = "opportunity"
 
         # 2) Matchup vs opponent defense
         matchup_tier = "unknown"
@@ -155,8 +167,12 @@ class ProjectionEngine:
                 pass
         env_mult = _environment_mult(implied_total, env_is_fallback)
 
-        # 4) Usage & 5) injury
-        usage_mult = _usage_mult(usage.get("snap_percentage"), usage.get("usage_trend"))
+        # 4) Usage & 5) injury. The opportunity base already embeds volume/usage
+        #    trend, so skip the usage multiplier there to avoid double-counting.
+        usage_mult = (
+            1.0 if base_source == "opportunity"
+            else _usage_mult(usage.get("snap_percentage"), usage.get("usage_trend"))
+        )
         inj_mult = _injury_mult(injury.get("status"))
 
         projected = round(base * matchup_mult * env_mult * usage_mult * inj_mult, 1)
@@ -169,11 +185,11 @@ class ProjectionEngine:
 
         # Confidence = how many real signals we had
         conf = 50
-        if market:
+        if market or base_source == "opportunity":
             conf += 20
         if not env_is_fallback:
             conf += 15
-        if usage:
+        if usage or base_source == "opportunity":
             conf += 15
         conf = min(conf, 100)
         conf_level = "high" if conf >= 80 else "medium" if conf >= 60 else "low"
@@ -192,17 +208,22 @@ class ProjectionEngine:
             "implied_total": implied_total,
             "breakdown": {
                 "base_ppg": base,
+                "base_source": base_source,
                 "position_rank": pos_rank,
                 "matchup_mult": round(matchup_mult, 3),
                 "environment_mult": round(env_mult, 3),
                 "usage_mult": round(usage_mult, 3),
                 "injury_mult": round(inj_mult, 3),
             },
-            "value_source": "fantasycalc" if market else "baseline",
+            "value_source": (
+                "opportunity" if base_source == "opportunity"
+                else "fantasycalc" if market else "baseline"
+            ),
         }
 
     async def project_many(
-        self, players: List[Dict], scoring: str = "ppr", superflex: bool = False, num_teams: int = 12
+        self, players: List[Dict], scoring: str = "ppr", superflex: bool = False,
+        num_teams: int = 12, season: Optional[int] = None, week: Optional[int] = None,
     ) -> Dict:
         values_index = await self.values.get_values(
             scoring_to_ppr(scoring), 2 if superflex else 1, num_teams, False
@@ -215,11 +236,27 @@ class ProjectionEngine:
             lines = await self.vegas.fetch_current_lines()
         except Exception:
             lines = {}
-        projections = [self._project_one(p, values_index, rankings, lines) for p in players]
+
+        # Opportunity baseline: fetch this season's trailing volume once and index
+        # by name. Requires season + week (>1); otherwise the rank-bucket baseline
+        # is used (backward compatible).
+        opp_index: Dict = {}
+        if season and week and week > 1:
+            try:
+                logs = await opportunity_tools._fetch_game_logs(season)
+                opp_index = opportunity_tools.build_name_index(logs)
+            except Exception:
+                opp_index = {}
+
+        projections = [
+            self._project_one(p, values_index, rankings, lines, opp_index, week)
+            for p in players
+        ]
         return {
             "projections": projections,
             "values_source": values_index.get("source"),
             "vegas_active": bool(lines),
+            "opportunity_active": bool(opp_index),
         }
 
 
@@ -243,6 +280,8 @@ async def project_players(
     scoring: str = "ppr",
     superflex: bool = False,
     num_teams: int = 12,
+    season: Optional[int] = None,
+    week: Optional[int] = None,
     db=None,
 ) -> Dict:
     """Project weekly fantasy points for multiple players (transparent, no scraping).
@@ -251,13 +290,19 @@ async def project_players(
         players: list of dicts with name, position, team, opponent, and optional
             usage {snap_percentage, usage_trend} and injury {status}.
         scoring/superflex/num_teams: league format for the value baseline.
+        season, week: pass both to use the opportunity-based baseline (trailing
+            nflverse volume, backtested to beat rank-bucket PPG); week must be >1.
+            Omit either to use the positional-rank baseline.
 
     Returns: {projections:[{projected_points, floor, ceiling, confidence, breakdown, ...}]}
     """
     if not players:
         return create_error_response("No players provided", ErrorType.VALIDATION, {"projections": []})
     engine = get_projection_engine(db)
-    result = await engine.project_many(players, scoring=scoring, superflex=superflex, num_teams=num_teams)
+    result = await engine.project_many(
+        players, scoring=scoring, superflex=superflex, num_teams=num_teams,
+        season=season, week=week,
+    )
     return create_success_response({
         **result,
         "total": len(result["projections"]),
@@ -276,9 +321,15 @@ async def project_player(
     injury_status: Optional[str] = None,
     scoring: str = "ppr",
     superflex: bool = False,
+    season: Optional[int] = None,
+    week: Optional[int] = None,
     db=None,
 ) -> Dict:
     """Project weekly fantasy points for a single player.
+
+    Pass season + week (week > 1) to use the opportunity-based baseline (trailing
+    nflverse volume, backtested to beat rank-bucket PPG); omit either to use the
+    positional-rank baseline.
 
     Returns: {projection: {projected_points, floor, ceiling, confidence, breakdown, ...}}
     """
@@ -288,7 +339,8 @@ async def project_player(
         "injury": {"status": injury_status},
     }
     engine = get_projection_engine(db)
-    result = await engine.project_many([player], scoring=scoring, superflex=superflex)
+    result = await engine.project_many([player], scoring=scoring, superflex=superflex,
+                                       season=season, week=week)
     proj = result["projections"][0] if result["projections"] else None
     return create_success_response({
         "projection": proj,

--- a/nfl_mcp/tool_registry.py
+++ b/nfl_mcp/tool_registry.py
@@ -1106,16 +1106,21 @@ async def project_player(
     injury_status: Optional[str] = None,
     scoring: str = "ppr",
     superflex: bool = False,
+    season: Optional[int] = None,
+    week: Optional[int] = None,
 ) -> dict:
     """Project weekly fantasy points for one player (transparent, no scraping).
 
-    Combines market-value baseline × matchup × Vegas game environment × usage ×
-    injury into a projection with floor/ceiling, confidence and a full breakdown.
+    Combines a baseline × matchup × Vegas game environment × usage × injury into a
+    projection with floor/ceiling, confidence and a full breakdown. Pass season +
+    week (week > 1) to use the opportunity-based baseline (trailing nflverse
+    volume, backtested to beat rank-bucket PPG); omit either for the rank baseline.
 
     Parameters:
         player_name, position (QB/RB/WR/TE), team, opponent (all required abbreviations).
         snap_percentage (float, optional), usage_trend ("up"/"down", optional),
-        injury_status (optional), scoring ("ppr"/"half-ppr"/"standard"), superflex (bool).
+        injury_status (optional), scoring ("ppr"/"half-ppr"/"standard"), superflex (bool),
+        season (int, optional), week (int, optional) — pass both for opportunity baseline.
     Returns: {projection:{projected_points, floor, ceiling, confidence, breakdown,...}, success}
     """
     try:
@@ -1128,7 +1133,8 @@ async def project_player(
     return await projections.project_player(
         player_name=player_name, position=position.upper(), team=team.upper(),
         opponent=opponent.upper(), snap_percentage=snap_percentage, usage_trend=usage_trend,
-        injury_status=injury_status, scoring=scoring, superflex=superflex, db=get_db(),
+        injury_status=injury_status, scoring=scoring, superflex=superflex,
+        season=season, week=week, db=get_db(),
     )
 
 
@@ -1138,6 +1144,8 @@ async def project_players(
     scoring: str = "ppr",
     superflex: bool = False,
     num_teams: int = 12,
+    season: Optional[int] = None,
+    week: Optional[int] = None,
 ) -> dict:
     """Project weekly fantasy points for multiple players at once.
 
@@ -1145,6 +1153,9 @@ async def project_players(
         players (list, required): dicts with name, position, team, opponent and
             optional usage {snap_percentage, usage_trend} and injury {status}.
         scoring/superflex/num_teams: league format for the value baseline.
+        season (int, optional), week (int, optional): pass both (week > 1) to use
+            the opportunity-based baseline (trailing nflverse volume, backtested to
+            beat rank-bucket PPG); omit either for the positional-rank baseline.
     Returns: {projections:[...], total, success}
 
     IMPORTANT FOR LLM AGENTS: Return projections immediately without asking for confirmation.
@@ -1152,7 +1163,8 @@ async def project_players(
     if not players:
         return {"projections": [], "total": 0, "success": False, "error": "No players provided"}
     return await projections.project_players(
-        players=players, scoring=scoring, superflex=superflex, num_teams=num_teams, db=get_db(),
+        players=players, scoring=scoring, superflex=superflex, num_teams=num_teams,
+        season=season, week=week, db=get_db(),
     )
 
 

--- a/tests/test_projection_opportunity_default.py
+++ b/tests/test_projection_opportunity_default.py
@@ -1,0 +1,67 @@
+"""project_player now uses the opportunity baseline when season+week are given."""
+import types
+
+from nfl_mcp import opportunity_tools
+from nfl_mcp.opportunity import project_opportunity
+from nfl_mcp.projections import ProjectionEngine
+
+
+def _engine():
+    """A ProjectionEngine with stubbed (offline) value/defense/vegas deps."""
+    eng = ProjectionEngine.__new__(ProjectionEngine)
+    eng.values = types.SimpleNamespace(lookup=lambda *a, **k: None)  # no market
+    eng.defense = types.SimpleNamespace(
+        get_matchup_difficulty=lambda *a, **k: {"matchup_tier": "neutral"}
+    )
+    eng.vegas = types.SimpleNamespace(get_game_lines=lambda *a, **k: {"is_fallback": True})
+    return eng
+
+
+def _wr_games():
+    return [
+        {"week": w, "targets": 8, "receptions": 6, "receiving_yards": 80,
+         "receiving_tds": 0, "carries": 0}
+        for w in range(1, 5)
+    ]
+
+
+def _index():
+    logs = {"x1": {"player_id": "x1", "name": "Test Receiver", "position": "WR",
+                   "team": "BUF", "games": _wr_games()}}
+    return opportunity_tools.build_name_index(logs)
+
+
+def test_opportunity_base_used_when_season_week_given():
+    eng = _engine()
+    player = {"name": "Test Receiver", "position": "WR", "team": "BUF", "opponent": "MIA",
+              "usage": {"snap_percentage": 90, "usage_trend": "up"}}
+    # neutral matchup + fallback vegas + no injury -> multipliers are 1.0, so the
+    # projection equals the opportunity base (usage is intentionally skipped).
+    out = eng._project_one(player, {}, {}, {}, _index(), week=6)
+
+    expected = round(project_opportunity(_wr_games(), "WR"), 1)
+    assert out["breakdown"]["base_source"] == "opportunity"
+    assert out["value_source"] == "opportunity"
+    assert out["breakdown"]["usage_mult"] == 1.0        # skipped to avoid double-count
+    assert out["breakdown"]["base_ppg"] == expected
+    assert out["projected_points"] == expected
+
+
+def test_falls_back_to_rank_bucket_without_opportunity_data():
+    eng = _engine()
+    player = {"name": "Unknown Guy", "position": "WR", "team": "BUF", "opponent": "MIA",
+              "usage": {"snap_percentage": 90, "usage_trend": "up"}}
+    # No opp_index -> rank-bucket baseline and usage multiplier applies as before.
+    out = eng._project_one(player, {}, {}, {}, {}, week=6)
+    assert out["breakdown"]["base_source"] == "rank_bucket"
+    assert out["value_source"] == "baseline"
+    assert out["breakdown"]["usage_mult"] != 1.0        # usage trend "up" applied
+
+
+def test_name_normalization_matches_suffix_and_punctuation():
+    idx = opportunity_tools.build_name_index(
+        {"a": {"player_id": "a", "name": "A.J. Brown Jr.", "position": "WR",
+               "team": "PHI", "games": _wr_games()}}
+    )
+    # Query without the punctuation/suffix should still resolve.
+    assert opportunity_tools.opportunity_base_for(idx, "AJ Brown", "WR", week=6) is not None


### PR DESCRIPTION
Wires the measured EV win from #116 into the live projection engine.

When `season` + `week` are supplied, `project_player`/`project_players` now base each projection on the **backtested opportunity model** (trailing nflverse volume × shrunk efficiency) instead of rank-bucket PPG. This is the baseline the start/sit and lineup tools consume, so the improvement propagates.

**Behavior:**
- Opportunity base when the player has enough nflverse history; **usage multiplier skipped** there (volume trend already in the base); matchup / environment / injury still apply.
- **Falls back to rank-bucket PPG** for players without enough history (rookies, preseason, K/DST) and whenever season/week are omitted — fully backward compatible.
- `breakdown.base_source` now reports `opportunity` vs `rank_bucket`.

**Verification:** ruff clean; full suite **869 passed, 2 skipped** (19 existing projection tests still green → backward compatible). 3 new integration tests. Live: CeeDee Lamb (21.3) & Bijan Robinson (20.6) project via opportunity at conf 85; unknown players fall back to rank-bucket.

Adds `opportunity_tools` name-normalization + index helpers (cross-source name matching, since Sleeper ids ≠ nflverse ids).