### PR TITLE
feat: win-probability lineup optimizer (ceiling as underdog, floor as favorite)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Win-probability lineup optimizer** (`nfl_mcp/win_probability.py` + new MCP
+  tool `get_win_probability_lineup`) — optimizes **P(beating a specific
+  opponent)** instead of E[points], the biggest strategic edge left in
+  season-long fantasy. Each player is a `Normal(mean, sd)` (sd from the
+  floor/ceiling band or position volatility); team totals combine so
+  `P(win) = Φ(Δmean / √Σvar)` (exact). Lineup selection maximizes P(win) via
+  local search over bench swaps, which **automatically recommends the ceiling
+  lineup when you're the underdog and the floor lineup when you're favored**, and
+  reports the win-probability gain over the points-optimal lineup. Composes with
+  `project_players`. (Independent players for now — QB/WR stacking correlation is
+  a future refinement.)
 - **Opportunity-based projection baseline** (`nfl_mcp/opportunity.py` + new MCP
   tool `get_opportunity_projections`) — projects next-week PPR points from
   recency-weighted trailing **volume** (targets/carries; QB pass attempts) ×

--- a/nfl_mcp/tool_registry.py
+++ b/nfl_mcp/tool_registry.py
@@ -33,6 +33,7 @@ from . import (
     waiver_tools,
     weather_tools,
     web_tools,
+    win_probability,
 )
 from .config import (
     FEATURE_LEAGUE_LEADERS,
@@ -161,6 +162,7 @@ def get_all_tools() -> List[Callable]:
         get_roster_recommendations,
         compare_players_for_slot,
         analyze_full_lineup,
+        get_win_probability_lineup,
         
         # Vegas Lines Tools (Game Environment Analysis)
         get_vegas_lines,
@@ -1851,6 +1853,45 @@ async def analyze_full_lineup(
     return await lineup_optimizer_tools.analyze_full_lineup(
         lineup=lineup,
         week=week
+    )
+
+
+@timing_decorator("get_win_probability_lineup", tool_type="lineup")
+async def get_win_probability_lineup(
+    your_players: List[dict],
+    opponent_players: List[dict],
+    slots: Optional[dict] = None,
+) -> dict:
+    """Pick the lineup that maximizes P(beating this specific opponent).
+
+    Optimizes win probability, not expected points — recommends the ceiling
+    lineup when you're the underdog and the floor lineup when you're favored
+    (the biggest strategic edge left in season-long fantasy). Feed the output of
+    `project_players` as the player lists.
+
+    Parameters:
+        your_players (list, required): your candidates, each with projected_points
+            and ideally floor/ceiling or sd, plus name and position.
+        opponent_players (list, required): the opponent's projected starters.
+        slots (dict, optional): roster slots (default QB1/RB2/WR2/TE1/FLEX1/K1/DST1;
+            FLEX = RB/WR/TE, SUPERFLEX adds QB).
+
+    Returns: {
+        recommended_lineup, win_probability, projected_points,
+        opponent_projected_points, projected_margin, you_are, strategy,
+        points_optimal_lineup, points_optimal_win_probability,
+        win_probability_gain, success, error?
+    }
+
+    Example: get_win_probability_lineup(your_players=[...], opponent_players=[...])
+
+    IMPORTANT FOR LLM AGENTS: Compute and render the recommendation immediately
+    without asking for confirmation.
+    """
+    return await win_probability.get_win_probability_lineup(
+        your_players=your_players,
+        opponent_players=opponent_players,
+        slots=slots,
     )
 
 

--- a/nfl_mcp/win_probability.py
+++ b/nfl_mcp/win_probability.py
@@ -1,0 +1,226 @@
+"""Win-probability lineup optimization.
+
+Season-long fantasy is decided by P(win), not E[points]. Against a strong
+opponent you want *ceiling* (variance helps you catch up); against a weak one you
+want *floor* (variance can only cost you). This module optimizes the lineup that
+maximizes the probability of outscoring a *specific* opponent — which naturally
+tilts ceiling-first when you're the underdog and floor-first when you're favored.
+
+Each player is a Normal(mean, sd) where mean is the projection and sd comes from
+the floor/ceiling band (or a position volatility fallback). Team score is the sum
+(treated as independent — QB/WR stacking correlation is a future refinement), so
+
+    P(win) = Φ( (mean_you - mean_opp) / sqrt(var_you + var_opp) )
+
+is exact. Lineup selection maximizes that P(win) via local search over bench
+swaps, so the objective itself decides floor vs ceiling.
+"""
+from __future__ import annotations
+
+import math
+from typing import Dict, List, Optional, Tuple
+
+from .errors import create_success_response, handle_http_errors, handle_validation_error
+from .projections import _VOLATILITY
+
+FLEX_ELIGIBLE = {"RB", "WR", "TE"}
+SUPERFLEX_ELIGIBLE = {"QB", "RB", "WR", "TE"}
+DEFAULT_SLOTS = {"QB": 1, "RB": 2, "WR": 2, "TE": 1, "FLEX": 1, "K": 1, "DST": 1}
+_MAX_SWAP_ITERS = 50
+
+
+def _phi(z: float) -> float:
+    """Standard normal CDF."""
+    return 0.5 * (1.0 + math.erf(z / math.sqrt(2.0)))
+
+
+def win_prob(my_mean: float, my_var: float, opp_mean: float, opp_var: float) -> float:
+    """P(my score > opponent score) for two independent Normal team totals."""
+    total_var = my_var + opp_var
+    if total_var <= 0:
+        return 1.0 if my_mean > opp_mean else 0.5 if my_mean == opp_mean else 0.0
+    return _phi((my_mean - opp_mean) / math.sqrt(total_var))
+
+
+def player_mean(p: Dict) -> float:
+    return float(p.get("projected_points", p.get("mean", 0.0)) or 0.0)
+
+
+def player_sd(p: Dict) -> float:
+    """Per-player standard deviation from sd, else the floor/ceiling band, else
+    a position-volatility fallback."""
+    if p.get("sd") is not None:
+        return max(0.0, float(p["sd"]))
+    mean = player_mean(p)
+    floor, ceiling = p.get("floor"), p.get("ceiling")
+    if floor is not None and ceiling is not None and ceiling > floor:
+        return (float(ceiling) - float(floor)) / 2.0
+    vol = _VOLATILITY.get((p.get("position") or "").upper(), 0.35)
+    return mean * vol
+
+
+def _eligible(slot: str, position: str) -> bool:
+    slot, pos = slot.upper(), (position or "").upper()
+    if slot == "FLEX":
+        return pos in FLEX_ELIGIBLE
+    if slot == "SUPERFLEX":
+        return pos in SUPERFLEX_ELIGIBLE
+    if slot in ("DST", "DEF"):
+        return pos in ("DST", "DEF")
+    return pos == slot
+
+
+def expand_slots(slots: Dict[str, int]) -> List[str]:
+    out: List[str] = []
+    for slot, n in slots.items():
+        out.extend([slot.upper()] * int(n))
+    return out
+
+
+def _team_stats(players: List[Dict]) -> Tuple[float, float]:
+    """(total mean, total variance) treating players as independent."""
+    mean = sum(player_mean(p) for p in players)
+    var = sum(player_sd(p) ** 2 for p in players)
+    return mean, var
+
+
+def greedy_mean_lineup(candidates: List[Dict], slot_list: List[str]) -> List[Optional[Dict]]:
+    """Fill each slot with the highest-mean eligible unused player (FLEX last)."""
+    # Fill specific positions before FLEX/SUPERFLEX so flex takes leftovers.
+    order = sorted(range(len(slot_list)), key=lambda i: slot_list[i] in ("FLEX", "SUPERFLEX"))
+    pool = sorted(candidates, key=player_mean, reverse=True)
+    used: set = set()
+    assignment: List[Optional[Dict]] = [None] * len(slot_list)
+    for i in order:
+        for p in pool:
+            if id(p) in used:
+                continue
+            if _eligible(slot_list[i], p.get("position")):
+                assignment[i] = p
+                used.add(id(p))
+                break
+    return assignment
+
+
+def _p_win_of(lineup: List[Optional[Dict]], opp_mean: float, opp_var: float) -> float:
+    starters = [p for p in lineup if p is not None]
+    my_mean, my_var = _team_stats(starters)
+    return win_prob(my_mean, my_var, opp_mean, opp_var)
+
+
+def optimize_win_probability(
+    candidates: List[Dict],
+    opponent_players: List[Dict],
+    slots: Optional[Dict[str, int]] = None,
+) -> Dict:
+    """Pick the lineup maximizing P(win) vs the given opponent.
+
+    Returns the recommended lineup, its win probability, the E[points]-optimal
+    lineup for comparison, and a floor/ceiling strategy label.
+    """
+    slots = slots or DEFAULT_SLOTS
+    slot_list = expand_slots(slots)
+    opp_mean, opp_var = _team_stats(opponent_players)
+
+    mean_lineup = greedy_mean_lineup(candidates, slot_list)
+    mean_p_win = _p_win_of(mean_lineup, opp_mean, opp_var)
+
+    # Local search: greedily apply the bench swap that most improves P(win).
+    current = list(mean_lineup)
+    current_p = mean_p_win
+    for _ in range(_MAX_SWAP_ITERS):
+        in_lineup = {id(p) for p in current if p is not None}
+        best_gain, best_swap = 1e-9, None
+        for i, slot in enumerate(slot_list):
+            for b in candidates:
+                if id(b) in in_lineup or not _eligible(slot, b.get("position")):
+                    continue
+                trial = list(current)
+                trial[i] = b
+                gain = _p_win_of(trial, opp_mean, opp_var) - current_p
+                if gain > best_gain:
+                    best_gain, best_swap = gain, (i, b)
+        if not best_swap:
+            break
+        i, b = best_swap
+        current[i] = b
+        current_p = _p_win_of(current, opp_mean, opp_var)
+
+    def _fmt(lineup):
+        return [
+            {"slot": slot_list[i], "player": p.get("name") or p.get("player"),
+             "position": (p.get("position") or "").upper(),
+             "mean": round(player_mean(p), 1), "sd": round(player_sd(p), 1)}
+            for i, p in enumerate(lineup) if p is not None
+        ]
+
+    rec_starters = [p for p in current if p is not None]
+    rec_mean, rec_var = _team_stats(rec_starters)
+    mo_starters = [p for p in mean_lineup if p is not None]
+    _, mo_var = _team_stats(mo_starters)
+
+    underdog = rec_mean < opp_mean
+    if rec_var > mo_var * 1.02:
+        strategy = "ceiling (chase variance — you're the underdog)"
+    elif rec_var < mo_var * 0.98:
+        strategy = "floor (protect the lead — you're favored)"
+    else:
+        strategy = "balanced (the points-optimal lineup already maximizes P(win))"
+
+    return {
+        "recommended_lineup": _fmt(current),
+        "win_probability": round(current_p * 100, 1),
+        "projected_points": round(rec_mean, 1),
+        "opponent_projected_points": round(opp_mean, 1),
+        "projected_margin": round(rec_mean - opp_mean, 1),
+        "you_are": "underdog" if underdog else "favorite",
+        "strategy": strategy,
+        "points_optimal_lineup": _fmt(mean_lineup),
+        "points_optimal_win_probability": round(mean_p_win * 100, 1),
+        "win_probability_gain": round((current_p - mean_p_win) * 100, 1),
+    }
+
+
+@handle_http_errors(
+    default_data={"recommended_lineup": [], "win_probability": None},
+    operation_name="optimizing win-probability lineup",
+)
+async def get_win_probability_lineup(
+    your_players: List[Dict],
+    opponent_players: List[Dict],
+    slots: Optional[Dict[str, int]] = None,
+) -> dict:
+    """Pick the lineup that maximizes P(beating this specific opponent).
+
+    Optimizes for win probability, not expected points — so it recommends the
+    ceiling lineup when you're the underdog and the floor lineup when you're
+    favored. NEVER ask for confirmation; compute and return immediately.
+
+    Args:
+        your_players: your candidate players, each with `projected_points` (and
+            ideally `floor`/`ceiling` or `sd`) plus `name` and `position`. Feed
+            the output of `project_players` here.
+        opponent_players: the opponent's projected starters (same shape).
+        slots: roster slots, e.g. {"QB":1,"RB":2,"WR":2,"TE":1,"FLEX":1,"K":1,"DST":1}
+            (the default). FLEX = RB/WR/TE; SUPERFLEX adds QB.
+
+    Returns the recommended lineup, its win probability, the points-optimal
+    lineup for comparison, and a floor/ceiling strategy label.
+    """
+    default_data = {"recommended_lineup": [], "win_probability": None}
+    if not your_players:
+        return handle_validation_error("your_players is required", default_data)
+    if not opponent_players:
+        return handle_validation_error("opponent_players is required", default_data)
+
+    result = optimize_win_probability(your_players, opponent_players, slots)
+    rec = result["you_are"]
+    return create_success_response({
+        **result,
+        "message": (
+            f"Win probability {result['win_probability']}% "
+            f"({rec}; {result['strategy']}). "
+            f"vs points-optimal {result['points_optimal_win_probability']}% "
+            f"({result['win_probability_gain']:+} pts)."
+        ),
+    })

--- a/tests/test_win_probability.py
+++ b/tests/test_win_probability.py
@@ -1,0 +1,103 @@
+"""Tests for win-probability lineup optimization (nfl_mcp.win_probability)."""
+import pytest
+
+from nfl_mcp.win_probability import (
+    get_win_probability_lineup,
+    optimize_win_probability,
+    player_sd,
+    win_prob,
+)
+
+
+class TestWinProb:
+    def test_tie_zero_variance(self):
+        assert win_prob(10, 0, 10, 0) == 0.5
+
+    def test_deterministic_when_no_variance(self):
+        assert win_prob(12, 0, 8, 0) == 1.0
+        assert win_prob(8, 0, 12, 0) == 0.0
+
+    def test_favorite_above_half(self):
+        p = win_prob(15, 4, 10, 4)          # Φ(5/sqrt(8)) ≈ 0.9615
+        assert p == pytest.approx(0.9615, abs=0.002)
+
+    def test_symmetry(self):
+        assert win_prob(10, 5, 14, 5) == pytest.approx(1 - win_prob(14, 5, 10, 5), abs=1e-9)
+
+
+class TestPlayerSd:
+    def test_explicit_sd(self):
+        assert player_sd({"sd": 4.0}) == 4.0
+
+    def test_from_floor_ceiling_band(self):
+        assert player_sd({"projected_points": 12, "floor": 8, "ceiling": 16}) == 4.0
+
+    def test_position_volatility_fallback(self):
+        # WR volatility 0.38 -> sd = 10 * 0.38 = 3.8
+        assert player_sd({"projected_points": 10, "position": "WR"}) == pytest.approx(3.8)
+
+
+class TestOptimizeWinProbability:
+    def test_underdog_tilts_to_ceiling(self):
+        # Opponent is strong; a boom/bust WR beats the steady one on P(win).
+        candidates = [
+            {"name": "Steady", "position": "WR", "projected_points": 12, "sd": 3},
+            {"name": "Boom", "position": "WR", "projected_points": 11, "sd": 8},
+        ]
+        opp = [{"name": "Star", "position": "WR", "projected_points": 16, "sd": 3}]
+        res = optimize_win_probability(candidates, opp, slots={"WR": 1})
+
+        assert res["you_are"] == "underdog"
+        assert res["recommended_lineup"][0]["player"] == "Boom"
+        assert res["points_optimal_lineup"][0]["player"] == "Steady"
+        assert res["win_probability"] > res["points_optimal_win_probability"]
+        assert "ceiling" in res["strategy"]
+
+    def test_favorite_tilts_to_floor(self):
+        # Opponent is weak; the low-variance WR protects the lead better.
+        candidates = [
+            {"name": "Boom", "position": "WR", "projected_points": 12, "sd": 8},
+            {"name": "Steady", "position": "WR", "projected_points": 11.5, "sd": 2},
+        ]
+        opp = [{"name": "Scrub", "position": "WR", "projected_points": 8, "sd": 3}]
+        res = optimize_win_probability(candidates, opp, slots={"WR": 1})
+
+        assert res["you_are"] == "favorite"
+        assert res["recommended_lineup"][0]["player"] == "Steady"
+        assert res["points_optimal_lineup"][0]["player"] == "Boom"
+        assert res["win_probability"] > res["points_optimal_win_probability"]
+        assert "floor" in res["strategy"]
+
+    def test_flex_eligibility_and_slot_fill(self):
+        candidates = [
+            {"name": "QB1", "position": "QB", "projected_points": 20, "sd": 4},
+            {"name": "RB1", "position": "RB", "projected_points": 15, "sd": 5},
+            {"name": "WR1", "position": "WR", "projected_points": 14, "sd": 5},
+            {"name": "TE1", "position": "TE", "projected_points": 9, "sd": 4},
+        ]
+        opp = [{"name": "O", "position": "QB", "projected_points": 18, "sd": 4}]
+        res = optimize_win_probability(candidates, opp, slots={"QB": 1, "FLEX": 1})
+        slots = {r["slot"] for r in res["recommended_lineup"]}
+        assert slots == {"QB", "FLEX"}
+        flex = next(r for r in res["recommended_lineup"] if r["slot"] == "FLEX")
+        assert flex["position"] in {"RB", "WR", "TE"}   # QB not FLEX-eligible
+
+
+class TestGetWinProbabilityLineupTool:
+    @pytest.mark.asyncio
+    async def test_returns_success(self):
+        res = await get_win_probability_lineup(
+            your_players=[{"name": "A", "position": "WR", "projected_points": 12, "sd": 4}],
+            opponent_players=[{"name": "B", "position": "WR", "projected_points": 10, "sd": 4}],
+            slots={"WR": 1},
+        )
+        assert res["success"] is True
+        assert res["win_probability"] > 50
+        assert res["recommended_lineup"][0]["player"] == "A"
+
+    @pytest.mark.asyncio
+    async def test_validation(self):
+        r1 = await get_win_probability_lineup(your_players=[], opponent_players=[{"x": 1}])
+        r2 = await get_win_probability_lineup(your_players=[{"x": 1}], opponent_players=[])
+        assert r1["success"] is False and "your_players" in r1["error"]
+        assert r2["success"] is False and "opponent_players" in r2["error"]


### PR DESCRIPTION
The biggest strategic edge left in season-long fantasy: optimize **P(win)** against a *specific* opponent, not E[points].

## How
Each player is a `Normal(mean, sd)` — sd from the floor/ceiling band, else a position-volatility fallback. Team totals combine (independent for now), so
```
P(win) = Φ( (mean_you − mean_opp) / √(var_you + var_opp) )
```
is exact (no simulation needed). Lineup selection maximizes that P(win) via **local search over bench swaps**, so the objective itself decides the tilt: **ceiling when you're the underdog, floor when you're favored.**

## Tool
`get_win_probability_lineup(your_players, opponent_players, slots?)` — feed the output of `project_players`. Returns the recommended lineup, its win probability, the points-optimal lineup for comparison, the win-probability gain, and a floor/ceiling strategy label. Slots default to QB/RB×2/WR×2/TE/FLEX/K/DST (FLEX = RB/WR/TE, SUPERFLEX adds QB).

## Verification
- 12 tests (P(win) math, sd derivation, FLEX eligibility, both strategy scenarios, tool validation).
- `ruff check .` clean; full suite **881 passed, 2 skipped**.
- **Demo (same roster, one FLEX slot):** vs a *strong* opponent it starts the boom/bust WR — **P(win) 22.9% vs 8.1%** points-optimal (+14.8); vs a *weak* opponent it starts the steady RB.

## Notes
- Players are treated as independent; **QB+WR (stack) correlation** is a natural next refinement (would raise ceiling for correlated pairs).
- Pairs well with the opportunity baseline (better means → better P(win) inputs).