### PR TITLE
feat: handcuff mapping (depth-chart backup + availability)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Handcuff mapping** (`nfl_mcp/handcuff_tools.py` + new MCP tool
+  `get_handcuff_map`) — for each RB on your Sleeper roster it reads the team
+  depth chart, identifies the contingent-value backup, and flags whether that
+  handcuff is a **free agent** (grab it), **yours** (secured) or an
+  **opponent's**, listing securable free agents first. Turns the usual "secure
+  your handcuffs" advice into an actionable list. Verified live (CMC → Jordan
+  James, Saquon Barkley → Tank Bigsby); the depth-chart parsing was corrected to
+  ESPN's real grid shape (each row is a starter + backups, injury tags stripped).
 - **Win-probability lineup optimizer** (`nfl_mcp/win_probability.py` + new MCP
   tool `get_win_probability_lineup`) — optimizes **P(beating a specific
   opponent)** instead of E[points], the biggest strategic edge left in

--- a/nfl_mcp/handcuff_tools.py
+++ b/nfl_mcp/handcuff_tools.py
@@ -1,0 +1,172 @@
+"""Handcuff mapping.
+
+A *handcuff* is the backup who would inherit a starter's workload — and fantasy
+value — if the starter went down (almost always the RB behind a lead back). This
+turns the usual "secure your handcuffs" advice into data: for each of your RB
+starters it reads the team depth chart, finds the contingent-value back, and
+flags whether that handcuff is a free agent, on your roster, or an opponent's.
+
+Depth chart: `nfl_tools.get_depth_chart` (ESPN). Rosters + availability:
+`sleeper_tools.get_rosters`. Player identity: the athletes cache.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Dict, List, Optional, Tuple
+
+from .errors import create_success_response, handle_http_errors, handle_validation_error
+from .opportunity_tools import norm_name
+
+logger = logging.getLogger(__name__)
+
+# ESPN's depth page is a grid: each row's first cell is the *starter* and the
+# rest are backups in depth order; player names carry a trailing injury tag
+# (e.g. "Isaac GuerendoO", "Christian KirkQ") we strip. There is no position
+# label per row — the row is keyed by the starter's name.
+
+
+def _clean_name(name: Optional[str]) -> str:
+    """Strip ESPN's trailing injury tag (Q/O/D/IR/PUP/SUS…) and whitespace."""
+    return re.sub(r"(?<=[a-z])[A-Z]+$", "", (name or "").strip())
+
+
+def handcuff_from_depth(depth_chart: List[Dict], starter_name: str) -> Tuple[Optional[str], str]:
+    """The immediate backup behind ``starter_name`` on the team's depth chart.
+
+    Returns ``(handcuff_name_or_None, method)``:
+      - ``depth`` — starter is a listed starter; the first backup is the handcuff.
+      - ``no_backup_listed`` — starter found but no backup behind them.
+      - ``you_roster_a_backup`` — the player is already a backup (they ARE the
+        contingent value, so no handcuff to chase).
+      - ``not_on_depth_chart`` — couldn't place them.
+    """
+    s = norm_name(starter_name)
+    # 1) Starter is a row key -> the first non-empty backup is the handcuff.
+    for row in depth_chart or []:
+        if norm_name(_clean_name(row.get("position"))) == s:
+            for p in row.get("players") or []:
+                cleaned = _clean_name(p)
+                if cleaned and cleaned != "-":
+                    return cleaned, "depth"
+            return None, "no_backup_listed"
+    # 2) Player appears only as a backup -> they're the contingent value already.
+    for row in depth_chart or []:
+        for p in row.get("players") or []:
+            if norm_name(_clean_name(p)) == s:
+                return None, "you_roster_a_backup"
+    return None, "not_on_depth_chart"
+
+
+def _availability(player_id: Optional[str], rostered: Dict[str, int], my_roster_id: int) -> str:
+    if not player_id or player_id not in rostered:
+        return "free_agent"
+    return "yours" if rostered[player_id] == my_roster_id else "rostered_by_opponent"
+
+
+@handle_http_errors(
+    default_data={"league_id": None, "roster_id": None, "handcuffs": []},
+    operation_name="mapping handcuffs",
+)
+async def get_handcuff_map(league_id: str, roster_id: int, db=None) -> dict:
+    """Map each of your RB starters to its handcuff + that handcuff's availability.
+
+    For every RB on your roster, reads the team's depth chart, identifies the
+    contingent-value back, and flags whether it's a free agent (grab it), on your
+    roster (secured), or an opponent's. NEVER ask for confirmation.
+
+    Args:
+        league_id: Sleeper league id.
+        roster_id: your roster id within that league.
+        db: database handle (athlete lookups); injected by the tool registry.
+
+    Returns a dict with `handcuffs` (one per RB, priority free-agents first).
+    """
+    from . import nfl_tools, sleeper_tools
+
+    default_data = {"league_id": league_id, "roster_id": roster_id, "handcuffs": []}
+    if db is None:
+        return handle_validation_error("database unavailable", default_data)
+
+    rosters_resp = await sleeper_tools.get_rosters(league_id)
+    rosters = rosters_resp.get("rosters") or []
+    if not rosters:
+        return handle_validation_error(
+            rosters_resp.get("error") or "No rosters found for league", default_data
+        )
+
+    # player_id -> roster_id, and locate your roster.
+    rostered: Dict[str, int] = {}
+    my_players: List[str] = []
+    for r in rosters:
+        rid = r.get("roster_id")
+        for pid in (r.get("players") or []):
+            rostered[pid] = rid
+        if rid == roster_id:
+            my_players = r.get("players") or []
+
+    if not my_players:
+        return handle_validation_error(
+            f"Roster {roster_id} not found or empty in league {league_id}", default_data
+        )
+
+    athletes = db.get_athletes_by_ids(my_players)
+    my_rbs = [a for a in athletes.values() if (a.get("position") or "").upper() == "RB"]
+
+    depth_cache: Dict[str, List[Dict]] = {}
+    team_athletes_cache: Dict[str, List[Dict]] = {}
+    handcuffs: List[Dict] = []
+
+    for rb in my_rbs:
+        starter = rb.get("full_name")
+        team = (rb.get("team_id") or "").upper()
+        entry = {"starter": starter, "team": team, "handcuff": None,
+                 "handcuff_status": None, "handcuff_player_id": None, "match": None}
+        if not team:
+            entry["match"] = "no_team"
+            handcuffs.append(entry)
+            continue
+
+        if team not in depth_cache:
+            try:
+                dc = await nfl_tools.get_depth_chart(team)
+                depth_cache[team] = dc.get("depth_chart") or []
+            except Exception as e:
+                logger.debug(f"depth chart fetch failed for {team}: {e}")
+                depth_cache[team] = []
+
+        handcuff_name, method = handcuff_from_depth(depth_cache[team], starter or "")
+        entry["match"] = method
+        if handcuff_name:
+            if team not in team_athletes_cache:
+                team_athletes_cache[team] = db.get_athletes_by_team(team) or []
+            hc_norm = norm_name(handcuff_name)
+            hc = next(
+                (a for a in team_athletes_cache[team] if norm_name(a.get("full_name")) == hc_norm),
+                None,
+            )
+            hc_id = hc.get("id") if hc else None
+            entry["handcuff"] = handcuff_name
+            entry["handcuff_player_id"] = hc_id
+            entry["handcuff_status"] = _availability(hc_id, rostered, roster_id)
+        handcuffs.append(entry)
+
+    # Priority: securable free-agent handcuffs first.
+    order = {"free_agent": 0, "rostered_by_opponent": 1, "yours": 2, None: 3}
+    handcuffs.sort(key=lambda h: order.get(h["handcuff_status"], 3))
+    free = [h for h in handcuffs if h["handcuff_status"] == "free_agent" and h["handcuff"]]
+
+    return create_success_response({
+        "league_id": league_id,
+        "roster_id": roster_id,
+        "handcuffs": handcuffs,
+        "priority_free_agents": [
+            {"handcuff": h["handcuff"], "for_starter": h["starter"], "team": h["team"]}
+            for h in free
+        ],
+        "count": len(handcuffs),
+        "message": (
+            f"Mapped {len(handcuffs)} RB handcuff(s); "
+            f"{len(free)} securable free-agent handcuff(s) — grab these to protect your backs."
+        ),
+    })

--- a/nfl_mcp/tool_registry.py
+++ b/nfl_mcp/tool_registry.py
@@ -17,6 +17,7 @@ from . import (
     coaching_tools,
     draft_tools,
     faab_tools,
+    handcuff_tools,
     lineup_optimizer_tools,
     matchup_tools,
     nfl_tools,
@@ -121,6 +122,7 @@ def get_all_tools() -> List[Callable]:
         check_re_entry_status,
         get_waiver_wire_dashboard,
         recommend_faab_bid,
+        get_handcuff_map,
         
         # Trade Analyzer Tools
         analyze_trade,
@@ -828,6 +830,40 @@ async def recommend_faab_bid(
     return await faab_tools.recommend_faab_bid(
         league_id=league_id, player_id=player_id, player_name=player_name,
         my_roster_id=my_roster_id, db=get_db(),
+    )
+
+
+@timing_decorator("get_handcuff_map", tool_type="waiver")
+async def get_handcuff_map(league_id: str, roster_id: int) -> dict:
+    """Map each of your RB starters to its handcuff + the handcuff's availability.
+
+    A handcuff is the backup who inherits a starter's workload on injury. For each
+    RB on your roster this reads the team depth chart, finds the contingent-value
+    back, and flags whether it's a free agent (grab it), yours (secured), or an
+    opponent's — turning "secure your handcuffs" into an actionable list.
+
+    Parameters:
+        league_id (str, required): Sleeper league id.
+        roster_id (int, required): your roster id in that league.
+
+    Returns: {
+        handcuffs: [{starter, team, handcuff, handcuff_status, handcuff_player_id, match}],
+        priority_free_agents: [{handcuff, for_starter, team}],
+        count, success, error?
+    }
+
+    Example: get_handcuff_map(league_id="123456789", roster_id=4)
+
+    IMPORTANT FOR LLM AGENTS: Compute and render the handcuff list immediately
+    without asking for confirmation.
+    """
+    try:
+        league_id = validate_string_input(league_id, 'league_id', max_length=32, required=True)
+        roster_id = validate_numeric_input(roster_id, min_val=1, max_val=32, required=True)
+    except ValueError as e:
+        return {"handcuffs": [], "success": False, "error": f"Invalid input: {str(e)}"}
+    return await handcuff_tools.get_handcuff_map(
+        league_id=league_id, roster_id=roster_id, db=get_db(),
     )
 
 

--- a/tests/test_handcuff_tools.py
+++ b/tests/test_handcuff_tools.py
@@ -1,0 +1,124 @@
+"""Tests for handcuff mapping (nfl_mcp.handcuff_tools)."""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nfl_mcp.handcuff_tools import (
+    _availability,
+    _clean_name,
+    get_handcuff_map,
+    handcuff_from_depth,
+)
+
+
+class TestCleanName:
+    def test_strips_injury_tags(self):
+        assert _clean_name("Christian KirkQ") == "Christian Kirk"
+        assert _clean_name("Isaac GuerendoO") == "Isaac Guerendo"
+        assert _clean_name("Deebo SamuelIR") == "Deebo Samuel"   # attached multi-letter tag
+        assert _clean_name("De'Zhaun Stribling") == "De'Zhaun Stribling"
+        assert _clean_name("-") == "-"
+
+
+class TestHandcuffFromDepth:
+    def test_first_backup_is_the_handcuff(self):
+        dc = [{"position": "Christian McCaffrey", "players": ["Jordan James", "Kaelon Black"]}]
+        assert handcuff_from_depth(dc, "Christian McCaffrey") == ("Jordan James", "depth")
+
+    def test_cleans_tags_on_key_and_backup(self):
+        dc = [{"position": "Isaac GuerendoO", "players": ["Backup GuyQ", "-"]}]
+        assert handcuff_from_depth(dc, "Isaac Guerendo") == ("Backup Guy", "depth")
+
+    def test_no_backup_listed(self):
+        dc = [{"position": "Lead Back", "players": ["-", "-"]}]
+        assert handcuff_from_depth(dc, "Lead Back") == (None, "no_backup_listed")
+
+    def test_player_is_already_a_backup(self):
+        dc = [{"position": "Star", "players": ["Your Guy", "Third"]}]
+        assert handcuff_from_depth(dc, "Your Guy") == (None, "you_roster_a_backup")
+
+    def test_not_on_chart(self):
+        dc = [{"position": "Star", "players": ["Backup"]}]
+        assert handcuff_from_depth(dc, "Traded Away") == (None, "not_on_depth_chart")
+
+
+class TestAvailability:
+    def test_free_agent(self):
+        assert _availability("x", {}, my_roster_id=1) == "free_agent"
+        assert _availability(None, {"x": 1}, my_roster_id=1) == "free_agent"
+
+    def test_yours_vs_opponent(self):
+        assert _availability("x", {"x": 1}, my_roster_id=1) == "yours"
+        assert _availability("x", {"x": 2}, my_roster_id=1) == "rostered_by_opponent"
+
+
+class _DB:
+    def __init__(self, by_id, by_team):
+        self._by_id, self._by_team = by_id, by_team
+
+    def get_athletes_by_ids(self, ids):
+        return {i: self._by_id[i] for i in ids if i in self._by_id}
+
+    def get_athletes_by_team(self, team):
+        return self._by_team.get(team, [])
+
+
+class TestGetHandcuffMap:
+    def _db(self):
+        return _DB(
+            by_id={
+                "rb_star": {"id": "rb_star", "full_name": "Star Back", "position": "RB", "team_id": "SF"},
+                "wr1": {"id": "wr1", "full_name": "Wide Guy", "position": "WR", "team_id": "SF"},
+            },
+            by_team={"SF": [
+                {"id": "rb_star", "full_name": "Star Back", "position": "RB"},
+                {"id": "hc1", "full_name": "Handcuff Back", "position": "RB"},
+            ]},
+        )
+
+    def _rosters(self, hc_owner=None):
+        rosters = [
+            {"roster_id": 1, "players": ["rb_star", "wr1"]},
+            {"roster_id": 2, "players": ["some_other"]},
+        ]
+        if hc_owner:
+            next(r for r in rosters if r["roster_id"] == hc_owner)["players"].append("hc1")
+        return {"rosters": rosters, "success": True}
+
+    async def _run(self, hc_owner=None):
+        # Real ESPN shape: row keyed by the starter, backups follow (with a tag).
+        depth = {"depth_chart": [{"position": "Star Back", "players": ["Handcuff BackO", "-"]}]}
+        with patch("nfl_mcp.sleeper_tools.get_rosters", new=AsyncMock(return_value=self._rosters(hc_owner))), \
+             patch("nfl_mcp.nfl_tools.get_depth_chart", new=AsyncMock(return_value=depth)):
+            return await get_handcuff_map("123", roster_id=1, db=self._db())
+
+    @pytest.mark.asyncio
+    async def test_free_agent_handcuff_is_priority(self):
+        res = await self._run(hc_owner=None)  # hc1 unrostered
+        assert res["success"] is True
+        hc = next(h for h in res["handcuffs"] if h["starter"] == "Star Back")
+        assert hc["handcuff"] == "Handcuff Back"        # injury tag stripped
+        assert hc["handcuff_player_id"] == "hc1"
+        assert hc["handcuff_status"] == "free_agent"
+        assert res["priority_free_agents"][0]["handcuff"] == "Handcuff Back"
+
+    @pytest.mark.asyncio
+    async def test_opponent_owned_handcuff(self):
+        res = await self._run(hc_owner=2)  # hc1 on opponent roster
+        hc = next(h for h in res["handcuffs"] if h["starter"] == "Star Back")
+        assert hc["handcuff_status"] == "rostered_by_opponent"
+        assert res["priority_free_agents"] == []
+
+    @pytest.mark.asyncio
+    async def test_roster_not_found(self):
+        with patch("nfl_mcp.sleeper_tools.get_rosters",
+                   new=AsyncMock(return_value={"rosters": [{"roster_id": 9, "players": []}]})):
+            res = await get_handcuff_map("123", roster_id=1, db=self._db())
+        assert res["success"] is False
+        assert "not found" in res["error"]
+
+    @pytest.mark.asyncio
+    async def test_db_required(self):
+        res = await get_handcuff_map("123", roster_id=1, db=None)
+        assert res["success"] is False
+        assert "database" in res["error"]


### PR DESCRIPTION
The last backlog fantasy feature: turn "secure your handcuffs" into data.

## What
`get_handcuff_map(league_id, roster_id)` — for each RB on your roster it reads the team depth chart, finds the **contingent-value backup** (who inherits the workload on injury), and flags whether that handcuff is a **free agent** (grab it), **yours** (secured) or an **opponent's**. Returns `priority_free_agents` first.

## Notable
The live e2e caught that ESPN's depth page is **not** position-labeled rows — it's a grid where each row is a *starter* + their backups in order, with injury tags attached to names (`Isaac GuerendoO`, `Christian KirkQ`). The parser now keys rows by the starter's name and strips tags. (The mocked tests initially encoded the wrong shape and passed — the live check is what surfaced it.)

## Verification
- 12 tests (tag cleaning, depth extraction incl. "already a backup", availability, tool paths).
- `ruff` clean; full suite **896 passed, 2 skipped**.
- **Live:** CMC → Jordan James, Saquon Barkley → Tank Bigsby.

## Note
Handcuffs are RB-focused (where the concept dominates); extending to a thin QB/TE room is a possible future add.