### PR TITLE
feat: free-agent availability filter for the streaming planner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   per team, mirror of the defense rankings) to power the DST/K signals, with the
   same prior-season fallback (`offense_source_season` / `*_is_fallback`).
   Verified end-to-end against real 2025 data (Lions the #1 K stream, as
-  expected). K improves further once the weather/wind factor lands.
+  expected). K improves further once the weather/wind factor lands. Optional
+  `league_id` annotates each option with **free-agent availability** (clean for
+  DST via the team-abbrev id; K/QB/TE/RB/WR list the team's players at that
+  position), and `only_available=True` keeps just the streamers you can actually
+  add.
 - **Strength-of-schedule tools** (`nfl_mcp/sos_tools.py`) — new MCP tools
   `get_strength_of_schedule` (arbitrary week range) and `get_playoff_sos`
   (fantasy weeks 15-17) that rank NFL teams by schedule difficulty per position

--- a/nfl_mcp/streaming_tools.py
+++ b/nfl_mcp/streaming_tools.py
@@ -164,6 +164,38 @@ def _needs_defense(positions: List[str]) -> bool:
     return any(p.upper() in DEFENSE_POSITIONS for p in positions)
 
 
+async def _rostered_ids(league_id: str) -> Tuple[set, bool]:
+    """Return (set of rostered player_ids, rosters_available)."""
+    from . import sleeper_tools
+    resp = await sleeper_tools.get_rosters(league_id)
+    rosters = resp.get("rosters") or []
+    rostered = {str(pid) for r in rosters for pid in (r.get("players") or [])}
+    return rostered, bool(rosters)
+
+
+def _unit_availability(position: str, team: str, rostered: set, db) -> Dict:
+    """Availability of a team's streamable unit at ``position`` in the league.
+
+    DST maps 1:1 (Sleeper DST id = team abbreviation). K/QB/TE/RB/WR enumerate the
+    team's players at that position from the athletes cache, each flagged
+    free_agent/rostered (a specific starter isn't singled out — a design note).
+    """
+    pos, team = position.upper(), (team or "").upper()
+    if pos in ("DST", "DEF"):
+        status = "rostered" if team in rostered else "free_agent"
+        return {"unit_player_id": team, "status": status, "has_free_agent": status == "free_agent"}
+    players = []
+    for a in (db.get_athletes_by_team(team) or []) if db else []:
+        if (a.get("position") or "").upper() == pos:
+            pid = str(a.get("id"))
+            players.append({
+                "player_id": pid,
+                "name": a.get("full_name"),
+                "status": "rostered" if pid in rostered else "free_agent",
+            })
+    return {"players": players, "has_free_agent": any(p["status"] == "free_agent" for p in players)}
+
+
 @handle_http_errors(
     default_data={"season": None, "weeks": [], "streaming_options": {}},
     operation_name="computing streaming options",
@@ -175,6 +207,8 @@ async def get_streaming_options(
     positions: Optional[List[str]] = None,
     strength_season: Optional[int] = None,
     top_n: int = 8,
+    league_id: Optional[str] = None,
+    only_available: bool = False,
 ) -> dict:
     """Rank weekly streaming options per position over the next 1-4 weeks.
 
@@ -192,6 +226,11 @@ async def get_streaming_options(
         strength_season: Season for the rankings prior (default auto: target
             season, else prior season before live data exists).
         top_n: Max options returned per position (default 8; 0 = all teams).
+        league_id: Sleeper league id — when given, each option is annotated with
+            free-agent availability (clean for DST; K/QB/TE/RB/WR list the team's
+            players at that position from the athletes cache).
+        only_available: with league_id, keep only options that have a free-agent
+            streamer (applied before top_n, so you get the top_n *available*).
 
     Returns a dict with ``streaming_options`` (per-position, best-first) plus
     ``defense_source_season`` / ``offense_source_season`` transparency fields.
@@ -229,10 +268,22 @@ async def get_streaming_options(
 
     scores = compute_streaming_scores(opponents, positions, def_rankings, off_rankings, analyzer)
 
+    # Optional free-agent availability from the league's rosters.
+    availability_active = False
+    rostered: set = set()
+    if league_id:
+        rostered, rosters_ok = await _rostered_ids(league_id)
+        availability_active = rosters_ok
+
     streaming_options: Dict[str, List[Dict]] = {}
     for pos, teams in scores.items():
         rows = [{"team": team, **data} for team, data in teams.items()]
         rows.sort(key=lambda r: r["stream_score"], reverse=True)
+        if availability_active:
+            for r in rows:
+                r["availability"] = _unit_availability(pos, r["team"], rostered, db)
+            if only_available:
+                rows = [r for r in rows if r["availability"]["has_free_agent"]]
         for i, r in enumerate(rows, 1):
             r["stream_rank"] = i
         streaming_options[pos] = rows[:top_n] if top_n else rows
@@ -244,6 +295,8 @@ async def get_streaming_options(
         notes.append("No live offense data — DST/K ratings are low-confidence.")
     if _needs_offense(positions) and not off_rankings:
         notes.append("No offense rankings available at all — DST/K could not be scored.")
+    if league_id and not availability_active:
+        notes.append(f"Could not load rosters for league {league_id} — availability not annotated.")
     notes.append("K accuracy improves with the weather/wind factor (planned).")
 
     return create_success_response({
@@ -254,6 +307,7 @@ async def get_streaming_options(
         "defense_is_fallback": def_fb,
         "offense_source_season": off_season,
         "offense_is_fallback": off_fb,
+        "availability_active": availability_active,
         "streaming_options": streaming_options,
         "stream_score_explained": (
             "0-100, higher = better weekly stream. QB/RB/WR/TE: softer opponent "

--- a/nfl_mcp/tool_registry.py
+++ b/nfl_mcp/tool_registry.py
@@ -1540,6 +1540,8 @@ async def get_streaming_options(
     positions: Optional[List[str]] = None,
     strength_season: Optional[int] = None,
     top_n: int = 8,
+    league_id: Optional[str] = None,
+    only_available: bool = False,
 ) -> dict:
     """Rank weekly streaming options per position over the next 1-4 weeks.
 
@@ -1549,6 +1551,10 @@ async def get_streaming_options(
     schedule-based and key-free: QB/RB/WR/TE = softer opponent defense; DST =
     weaker opponent offense; K = stronger own offense.
 
+    Pass `league_id` to annotate each option with free-agent availability (clean
+    for DST; K/QB/TE/RB/WR list the team's players at that position), and
+    `only_available=True` to keep only options with a free-agent streamer.
+
     Parameters:
         season (int, required): NFL season year.
         start_week (int, required): First week of the window (1-18).
@@ -1556,17 +1562,19 @@ async def get_streaming_options(
         positions (list, optional): Positions to plan (default QB/TE/DST/K).
         strength_season (int, optional): Rankings-prior season (default auto).
         top_n (int, optional): Max options per position (default 8; 0 = all).
+        league_id (str, optional): Sleeper league id for free-agent availability.
+        only_available (bool, optional): keep only free-agent-available options.
 
     Returns: {
         season, weeks, positions,
         defense_source_season, defense_is_fallback,
-        offense_source_season, offense_is_fallback,
-        streaming_options: {pos: [teams best-first with stream_rank/stream_score/weeks]},
+        offense_source_season, offense_is_fallback, availability_active,
+        streaming_options: {pos: [teams best-first with stream_rank/stream_score/weeks/availability]},
         notes: [str], success: bool, error?: str
     }
 
-    Example: get_streaming_options(season=2026, start_week=10, weeks_ahead=3,
-                                   positions=["DST", "K"])
+    Example: get_streaming_options(season=2026, start_week=10, positions=["DST", "K"],
+                                   league_id="123456789", only_available=True)
 
     IMPORTANT FOR LLM AGENTS: Compute and render the full ranking immediately
     without asking for confirmation.
@@ -1578,6 +1586,8 @@ async def get_streaming_options(
         positions=positions,
         strength_season=strength_season,
         top_n=top_n,
+        league_id=league_id,
+        only_available=only_available,
     )
 
 

--- a/tests/test_streaming_tools.py
+++ b/tests/test_streaming_tools.py
@@ -7,6 +7,7 @@ from nfl_mcp import matchup_tools
 from nfl_mcp.streaming_tools import (
     _resolve_offense,
     _strength_score,
+    _unit_availability,
     compute_streaming_scores,
     get_streaming_options,
 )
@@ -28,14 +29,18 @@ def _offense(entries):
 
 
 class _StubDB:
-    def __init__(self, schedule):
+    def __init__(self, schedule, athletes_by_team=None):
         self._schedule = schedule
+        self._athletes = athletes_by_team or {}
 
     def get_opponent(self, season, week, team):
         return self._schedule.get((season, week, team))
 
     def upsert_schedule_games(self, games):
         return len(games)
+
+    def get_athletes_by_team(self, team):
+        return self._athletes.get(team, [])
 
 
 class _StubAnalyzer:
@@ -209,3 +214,51 @@ class TestGetStreamingOptions:
             bad_ahead = await get_streaming_options(season=2026, start_week=10, weeks_ahead=9)
         assert bad_week["success"] is False and "start_week" in bad_week["error"]
         assert bad_ahead["success"] is False and "weeks_ahead" in bad_ahead["error"]
+
+
+class TestStreamingAvailability:
+    def test_unit_availability_dst_maps_to_team_abbrev(self):
+        free = _unit_availability("DST", "SF", rostered=set(), db=None)
+        assert free["status"] == "free_agent" and free["has_free_agent"] is True
+        taken = _unit_availability("DST", "SF", rostered={"SF"}, db=None)
+        assert taken["status"] == "rostered" and taken["has_free_agent"] is False
+
+    def test_unit_availability_kicker_from_athletes(self):
+        db = _StubDB({}, athletes_by_team={"SF": [
+            {"id": "k1", "full_name": "The Kicker", "position": "K"},
+            {"id": "wr9", "full_name": "A Receiver", "position": "WR"},  # ignored for K
+        ]})
+        avail = _unit_availability("K", "SF", rostered=set(), db=db)
+        assert avail["has_free_agent"] is True
+        assert [p["name"] for p in avail["players"]] == ["The Kicker"]
+        assert _unit_availability("K", "SF", rostered={"k1"}, db=db)["has_free_agent"] is False
+
+    @pytest.mark.asyncio
+    async def test_tool_annotates_and_filters_dst_availability(self):
+        def_by_season = {2026: _def_rankings({"QB": [("KC", 32, False), ("SF", 1, False)]})}
+        schedule = {(2026, 10, "BUF"): "KC", (2026, 10, "MIA"): "SF"}
+        analyzer = _StubAnalyzer(def_by_season, db=_StubDB(schedule))
+        offense = _offense({"KC": 1, "SF": 30, "BUF": 5, "MIA": 20})
+
+        async def fake_offense(season):
+            return offense if season == 2026 else {}
+
+        rosters = {"rosters": [{"roster_id": 1, "players": ["BUF"]}]}  # BUF DST taken, MIA free
+        with patch("nfl_mcp.matchup_tools.get_defense_analyzer", return_value=analyzer), \
+                patch("nfl_mcp.matchup_tools.fetch_offense_rankings", side_effect=fake_offense), \
+                patch("nfl_mcp.sleeper_tools.get_rosters", new=AsyncMock(return_value=rosters)):
+            annotated = await get_streaming_options(
+                season=2026, start_week=10, weeks_ahead=1, positions=["DST"], league_id="123"
+            )
+            filtered = await get_streaming_options(
+                season=2026, start_week=10, weeks_ahead=1, positions=["DST"],
+                league_id="123", only_available=True,
+            )
+
+        assert annotated["availability_active"] is True
+        by_team = {r["team"]: r for r in annotated["streaming_options"]["DST"]}
+        assert by_team["MIA"]["availability"]["status"] == "free_agent"
+        assert by_team["BUF"]["availability"]["status"] == "rostered"
+
+        teams = {r["team"] for r in filtered["streaming_options"]["DST"]}
+        assert "MIA" in teams and "BUF" not in teams   # only_available dropped the rostered DST


### PR DESCRIPTION
Refinement #2: make the streaming planner league-aware so it only surfaces streamers you can actually add.

## What
`get_streaming_options` gains optional **`league_id`** and **`only_available`**. With `league_id`, each ranked option is annotated with free-agent availability from the league's rosters:
- **DST** — clean 1:1 (Sleeper DST id = team abbreviation).
- **K / QB / TE / RB / WR** — lists the team's players at that position (each `free_agent`/`rostered`) from the athletes cache; a specific starter isn't singled out (honest design note).

`only_available=True` keeps only options with a free-agent streamer, applied **before** `top_n` so you get the top_n *available* streamers.

## Scope
As flagged when we discussed this: DST (the main streaming position) is exact; K/QB/TE availability depends on the athletes cache being populated (`fetch_athletes`). DST needs only the rosters.

## Verification
- 3 new tests (DST abbrev mapping; kicker from athletes; tool annotation + only_available filtering).
- `ruff` clean; full suite **899 passed, 2 skipped**.