### PR TITLE
chore: mypy report-only CI + fix type bugs; release 0.6.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,30 @@ jobs:
       - name: Ruff lint
         run: ruff check .
 
+  typecheck:
+    name: Type check (mypy, report-only)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+          pip install -e .
+
+      # Non-blocking: mypy is a signal while the codebase is progressively
+      # typed, not a merge gate. Surfaces real type bugs without failing CI.
+      - name: mypy
+        run: mypy nfl_mcp
+        continue-on-error: true
+
   test:
     name: Tests
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.5] - 2026-07-27
+
 ### Added
+- **Type checking (mypy) as a report-only CI job** — added a `[tool.mypy]`
+  config (lenient, `check_untyped_defs`) and a **non-blocking** `typecheck` CI
+  job. It's a signal while the code is progressively typed, not a merge gate.
+  The first pass already caught real bugs (see Fixed).
 - **Handcuff mapping** (`nfl_mcp/handcuff_tools.py` + new MCP tool
   `get_handcuff_map`) — for each RB on your Sleeper roster it reads the team
   depth chart, identifies the contingent-value backup, and flags whether that
@@ -130,6 +136,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   documented data sources.
 
 ### Fixed
+- **Missing `ErrorType.API_ERROR` / `ErrorType.NOT_FOUND`** — several error paths
+  in `sleeper_tools.py`/`nfl_tools.py` referenced these enum members, which
+  didn't exist, so hitting those paths raised `AttributeError`. Added the
+  members. Surfaced by the new mypy pass.
+- **Missing `database.get_nfl_database()`** — `nfl_tools` imported this factory
+  (advanced-enrichment cache paths) but it was never defined, raising
+  `ImportError` at runtime. Added it. Surfaced by the new mypy pass.
 - **Package `authors` metadata** — replaced the `nfl@example.com` placeholder
   with the real maintainer (`gtonic <tom.geiger@alp54.com>`).
 - **`get_draft_picks` silently returned un-enriched picks** — a duplicate,

--- a/nfl_mcp/database.py
+++ b/nfl_mcp/database.py
@@ -2403,3 +2403,14 @@ class NFLDatabase:
 
 # For backward compatibility
 AthleteDatabase = NFLDatabase
+
+
+def get_nfl_database() -> "NFLDatabase":
+    """Return an NFLDatabase instance.
+
+    Referenced by nfl_tools' (advanced-enrichment) cache-read paths, which
+    imported this factory before it existed — calling it raised ImportError at
+    runtime (surfaced by the mypy pass). The DB is a cache, so a fresh instance
+    is fine here.
+    """
+    return NFLDatabase()

--- a/nfl_mcp/errors.py
+++ b/nfl_mcp/errors.py
@@ -26,6 +26,10 @@ class ErrorType:
     UNEXPECTED = "unexpected_error"
     ACCESS_DENIED = "access_denied_error"
     ROSTER_PRIVATE = "roster_private_error"
+    # Referenced by sleeper_tools/nfl_tools error paths; were missing here, so
+    # hitting those paths raised AttributeError (surfaced by the mypy pass).
+    API_ERROR = "api_error"
+    NOT_FOUND = "not_found_error"
 
 
 def create_error_response(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfl_mcp"
-version = "0.6.0"
+version = "0.6.5"
 description = "NFL MCP Server - Fantasy Football Analysis via Model Context Protocol"
 authors = [{name = "gtonic", email = "tom.geiger@alp54.com"}]
 license = {text = "MIT"}
@@ -99,6 +99,15 @@ ignore = [
 # same retry-loop iteration (captured vars are re-bound each pass), so they are
 # false positives. Revisit when sleeper_tools.py is split by domain.
 "nfl_mcp/sleeper_tools.py" = ["B023"]
+
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true
+warn_unused_ignores = false
+# Report-only signal, not a gate (the CI job is non-blocking). This is a
+# dict-heavy, progressively-typed codebase, so some inference noise is expected;
+# the value is catching real type bugs (e.g. attribute typos, None misuse).
+check_untyped_defs = true
 
 [tool.coverage.run]
 source = ["nfl_mcp"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ pytest-asyncio>=1.4.0
 httpx>=0.28.1
 pytest-cov>=7.1.0
 ruff>=0.16.0
+mypy>=1.14.0


### PR DESCRIPTION
## Type checking (report-only) + real bug fixes
Introduces **mypy** as a **non-blocking** `typecheck` CI job with a lenient `[tool.mypy]` config (`check_untyped_defs`) — a signal while the code is progressively typed, not a merge gate. The first pass immediately caught **real bugs**, now fixed:
- **`ErrorType.API_ERROR` / `ErrorType.NOT_FOUND`** — referenced in `sleeper_tools`/`nfl_tools` error paths but never defined on the enum → `AttributeError` when hit. Added the members.
- **`database.get_nfl_database()`** — imported by `nfl_tools` (advanced-enrichment cache paths) but never defined → `ImportError` at runtime. Added the factory.

## Release 0.6.5
Version bump `0.6.0` → `0.6.5` (pyproject; `/health` reports it dynamically) + CHANGELOG release cut of everything since 0.6.0 (SSRF hardening, py3.11, 6 fantasy features, opportunity-default projections, README split, lint-debt cleanup, …).

## Docker
The CI already **builds a Docker image on every run** and **publishes to GHCR on `main`/tags** (`Build & publish image` job, semver-tagged). No change needed — **tagging `v0.6.5` after merge publishes `ghcr.io/gtonic/nfl_mcp:0.6.5`**.

## Verification
`ruff check .` clean; full suite **901 passed, 2 skipped**; mypy runs report-only (real bugs above no longer flagged).