### PR TITLE
chore(security): multi-stage Docker build — drop gcc/binutils from runtime image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Multi-stage Docker build — drops `gcc`/`binutils` from the runtime image.**
+  The build stage keeps the C toolchain (to compile any sdist-only dependency)
+  and installs everything into an isolated virtualenv; the runtime stage copies
+  only that venv, so the shipped image carries no `gcc`/`binutils`. `binutils`
+  was the source of the large majority of the image scanner's findings (broad
+  CVE surface, reported across ~8 sub-packages), so this removes that entire
+  class of CVEs — and shrinks the image. The remaining findings are Debian
+  base-OS packages Debian itself rates *negligible* with no fix available
+  (`under investigation`), inherent to any Debian-based image.
+
 ## [0.6.6] - 2026-07-27
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,71 @@
-# Use Python 3.13 slim image as base (bumped from 3.11 to clear the CPython
-# stdlib CVEs the image scanner flagged, which are fixed only in 3.13+).
-FROM python:3.13-slim
+# syntax=docker/dockerfile:1
+# ---------------------------------------------------------------------------
+# Multi-stage build.
+#
+# The build stage carries the C toolchain (gcc + its hard dependency binutils)
+# needed to compile any dependency that ships only an sdist. binutils alone
+# accounts for the large majority of the image scanner's findings (it parses
+# many binary formats -> broad CVE surface, and ships as ~8 sub-packages so each
+# CVE is reported 8x). By building into an isolated virtualenv and copying ONLY
+# that venv into a clean runtime stage, the final image carries no gcc/binutils
+# at all -- removing that entire class of findings and shrinking the image.
+# ---------------------------------------------------------------------------
 
-# Set environment variables
+# ---- Build stage -----------------------------------------------------------
+FROM python:3.13-slim AS builder
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    PYTHONPATH=/app
+    PYTHONUNBUFFERED=1
 
-# Set work directory
 WORKDIR /app
 
-# Install system dependencies. `apt-get upgrade` pulls the latest Debian
-# security patches (glibc/ncurses/sqlite/zlib/... CVEs). `curl` is intentionally
-# NOT installed — the health check uses Python's stdlib instead, so the image
-# carries no curl/libcurl. gcc is only needed to build C-extension wheels.
+# gcc/binutils live ONLY in this stage and never reach the runtime image.
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build into a self-contained virtualenv we can copy wholesale to the runtime
+# stage. The venv's interpreter symlinks resolve identically there because the
+# runtime stage uses the same python:3.13-slim base.
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Upgrade the bundled build tooling (wheel/setuptools) too -- the base image
+# ships older versions flagged by scanners (e.g. wheel GHSA-8rrh-rw8j-w5fx).
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+
+# Install pinned, reproducible dependencies. requirements.lock is generated via:
+#   uv pip compile requirements.txt --python-version 3.13 --output-file requirements.lock
+COPY requirements.lock .
+RUN pip install --no-cache-dir -r requirements.lock
+
+# Install the package itself into the venv.
+COPY . .
+RUN pip install --no-cache-dir -e .
+
+# ---- Runtime stage ---------------------------------------------------------
+FROM python:3.13-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app \
+    PATH="/opt/venv/bin:$PATH"
+
+WORKDIR /app
+
+# Pull the latest Debian security patches, but do NOT install gcc/binutils here
+# -- the runtime needs no C toolchain (all deps arrive as prebuilt wheels via
+# the copied venv).
+RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy the pinned lockfile and install exact, reproducible dependencies.
-# requirements.lock is generated from requirements.txt via:
-#   uv pip compile requirements.txt --python-version 3.13 --output-file requirements.lock
-COPY requirements.lock .
-# Upgrade the bundled build tooling too (wheel/setuptools) — the base image ships
-# older versions flagged by image scanners (e.g. wheel GHSA-8rrh-rw8j-w5fx).
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
-    && pip install --no-cache-dir -r requirements.lock
-
-# Copy project files
+# Copy the pre-built virtualenv (all deps + the installed package) and the app
+# source (the editable install and PYTHONPATH resolve nfl_mcp from /app).
+COPY --from=builder /opt/venv /opt/venv
 COPY . .
-
-# Install the package in development mode
-RUN pip install -e .
 
 # Create non-root user for security
 RUN useradd --create-home --shell /bin/bash app \
@@ -43,7 +75,7 @@ USER app
 # Expose the port
 EXPOSE 9000
 
-# Health check (Python stdlib — avoids depending on curl in the image)
+# Health check (Python stdlib -- avoids depending on curl in the image)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:9000/health', timeout=5).status == 200 else 1)" || exit 1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,13 @@ RUN apt-get update \
 COPY --from=builder /opt/venv /opt/venv
 COPY . .
 
+# Smoke test: fail the build if the copied venv can't import the full app graph
+# in this clean, toolchain-free runtime. `import nfl_mcp.server` transitively
+# imports the tool registry -> every tool module -> every (compiled) dependency
+# (lxml, pydantic-core, ...), so a broken venv copy or a missing wheel is caught
+# here rather than at container start. Side-effect-free (no server bind, no DB).
+RUN python -c "import nfl_mcp.server"
+
 # Create non-root user for security
 RUN useradd --create-home --shell /bin/bash app \
     && chown -R app:app /app


### PR DESCRIPTION
Follow-up to the 0.6.6 image scan. **~85% of the scanner's findings are `binutils`, present only because we `apt install gcc`** — gcc hard-depends on binutils, which has a broad CVE surface (parses many binary formats) and ships as ~8 sub-packages, so each CVE is reported 8×.

## Change
Split the Dockerfile into two stages:
- **builder** — keeps `gcc` (to compile any sdist-only dep), installs deps + the package into an isolated `/opt/venv`.
- **runtime** — clean `python:3.13-slim`, `apt upgrade` only, **no `gcc`/`binutils`**; copies just `/opt/venv` + the app source.

Our deps all publish prebuilt manylinux wheels for cp313, so the runtime needs no C toolchain.

## Effect
- Removes the **entire binutils CVE class** (the large majority of the scan) + shrinks the image.
- **Remaining findings** are Debian base-OS packages (glibc/util-linux/systemd/coreutils/perl/apt/tar/dpkg/sqlite) that Debian itself rates *negligible* with **no fix available** (`under investigation`) — inherent to any Debian-based image, nothing to patch.

## Verification
CI's **Build & publish image** job builds the multi-stage image end-to-end (validates that no dep needs the dropped toolchain). No app-code change.