### PR TITLE
chore(release): 0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.7] - 2026-07-27
+
 ### Security
 - **Multi-stage Docker build — drops `gcc`/`binutils` from the runtime image.**
   The build stage keeps the C toolchain (to compile any sdist-only dependency)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfl_mcp"
-version = "0.6.6"
+version = "0.6.7"
 description = "NFL MCP Server - Fantasy Football Analysis via Model Context Protocol"
 authors = [{name = "gtonic", email = "tom.geiger@alp54.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
Cuts **0.6.7**. Ships the multi-stage Docker build from #130 (gcc/binutils no longer in the runtime image → removes ~85% of the image-scanner findings). Version bump + CHANGELOG release cut only; no code change. Tagging `v0.6.7` after merge publishes `ghcr.io/gtonic/nfl_mcp:0.6.7` on the leaner 3.13 base.