### PR TITLE
feat(db): configurable SQLite cache path via NFL_MCP_DB_PATH (persistent volume)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Configurable database path via `NFL_MCP_DB_PATH`.** The SQLite cache path now
+  falls back to the `NFL_MCP_DB_PATH` environment variable (default
+  `nfl_data.db`). The default is resolved inside `NFLDatabase.__init__`, so
+  *every* `NFLDatabase()` call in the codebase honors it — point it at a mounted
+  volume (e.g. `NFL_MCP_DB_PATH=/data/nfl_data.db` + `-v nfl-mcp-data:/data`) to
+  persist the warmed cache across container restarts instead of re-initializing
+  each time. An explicit `db_path` argument (e.g. a test's temp file) still wins.
+
 ## [0.6.7] - 2026-07-27
 
 ### Security

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -52,7 +52,21 @@ task all          # full pipeline
 The SQLite database is only a **cache** (athletes, schedules, enrichment). It
 lives inside the container and repopulates from the source APIs on demand (e.g.
 `fetch_athletes` or background prefetch), so losing it on restart is harmless —
-**no volume required**.
+**no volume required**. If you'd rather *not* re-warm on every restart, set
+`NFL_MCP_DB_PATH` to a path on a mounted volume to persist it:
+
+```bash
+docker volume create nfl-mcp-data
+docker run -d --name nfl-mcp -p 9000:9000 \
+  -e NFL_MCP_DB_PATH=/data/nfl_data.db \
+  -v nfl-mcp-data:/data \
+  ghcr.io/gtonic/nfl_mcp:latest
+```
+
+A **named volume** is recommended over a host bind-mount — SQLite needs proper
+file locking, which named volumes provide reliably on Docker Desktop (macOS/
+Windows). The container runs as non-root uid 1000, so a bind-mounted host
+directory would need to be writable by that uid.
 
 ## Going live: connect your AI client
 
@@ -121,6 +135,7 @@ variables take precedence.
 |---|---|
 | `ODDS_API_KEY` | Enables live Vegas lines/totals ([the-odds-api.com](https://the-odds-api.com)). Without it, Vegas tools return neutral placeholders. Player values (FantasyCalc) need **no** key. |
 | `NFL_MCP_ADVANCED_ENRICH` | `1` enables snap%, opponent, practice status and usage-trend enrichment (Schema v8). Also lets schedule fetches run. |
+| `NFL_MCP_DB_PATH` | Path to the SQLite cache file (default `nfl_data.db`, relative to the working dir). Point it at a mounted volume — e.g. `/data/nfl_data.db` — to persist the warmed cache across restarts. |
 | `NFL_MCP_ALLOW_PRIVATE_URLS` | `1` lets `crawl_url` reach private/loopback addresses. Off by default (SSRF protection — see [SECURITY.md](../SECURITY.md)). |
 | `NFL_MCP_PREFETCH` | `1` enables background data prefetch (cache warming). |
 | `NFL_MCP_PREFETCH_INTERVAL` | Prefetch interval, seconds (default 900). |

--- a/nfl_mcp/database.py
+++ b/nfl_mcp/database.py
@@ -9,6 +9,7 @@ Features connection pooling, health checks, optimized indexing, migration suppor
 import asyncio
 import json
 import logging
+import os
 import sqlite3
 import threading
 import time
@@ -190,14 +191,22 @@ class NFLDatabase:
     # Database schema version for migrations
     CURRENT_SCHEMA_VERSION = 12
 
-    def __init__(self, db_path: str = "nfl_data.db", pool_config: ConnectionPoolConfig | None = None):
+    def __init__(self, db_path: str | None = None, pool_config: ConnectionPoolConfig | None = None):
         """
         Initialize the NFL database.
 
         Args:
-            db_path: Path to the SQLite database file
+            db_path: Path to the SQLite database file. When ``None`` (the
+                default), falls back to the ``NFL_MCP_DB_PATH`` environment
+                variable, or ``nfl_data.db`` if that is unset. Resolving the
+                default here means *every* ``NFLDatabase()`` call in the codebase
+                honors the configured path, so a persistent volume can be pointed
+                at (e.g. ``NFL_MCP_DB_PATH=/data/nfl_data.db``) without code
+                changes. An explicit ``db_path`` (e.g. a test's temp file) wins.
             pool_config: Configuration for connection pooling
         """
+        if db_path is None:
+            db_path = os.getenv("NFL_MCP_DB_PATH", "nfl_data.db")
         self.db_path = Path(db_path)
         self.pool_config = pool_config or ConnectionPoolConfig()
         self._pool = DatabaseConnectionPool(str(self.db_path), self.pool_config)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -349,3 +349,29 @@ class TestAthleteDatabase:
         assert athlete["team_id"] == ""  # Should be empty string, not None
         assert athlete["position"] == ""
         assert athlete["status"] == ""
+
+
+class TestDatabasePathConfig:
+    """The DB path is configurable via NFL_MCP_DB_PATH so a persistent volume can
+    be mounted without code changes (every no-arg NFLDatabase() honors it)."""
+
+    def test_env_var_sets_default_path(self, tmp_path, monkeypatch):
+        target = tmp_path / "sub" / "nfl_cache.db"
+        target.parent.mkdir(parents=True)
+        monkeypatch.setenv("NFL_MCP_DB_PATH", str(target))
+        db = NFLDatabase()  # no explicit path -> falls back to the env var
+        assert db.db_path == target
+        assert target.exists()  # _ensure_database created it at the configured path
+
+    def test_explicit_path_overrides_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("NFL_MCP_DB_PATH", str(tmp_path / "from_env.db"))
+        explicit = tmp_path / "explicit.db"
+        db = NFLDatabase(str(explicit))
+        assert db.db_path == explicit
+        assert not (tmp_path / "from_env.db").exists()
+
+    def test_default_when_env_unset(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("NFL_MCP_DB_PATH", raising=False)
+        monkeypatch.chdir(tmp_path)  # keep the default file out of the repo
+        db = NFLDatabase()
+        assert db.db_path == Path("nfl_data.db")


### PR DESCRIPTION
Lets the SQLite cache be pointed at a mounted volume so the warmed cache **survives container restarts** instead of re-initializing every time.

## Change
`NFLDatabase.__init__` resolves its default `db_path` from the **`NFL_MCP_DB_PATH`** env var (fallback `nfl_data.db`) when no explicit path is given. Resolving it in `__init__` — not just at the server entrypoint — means **all ~11 `NFLDatabase()` call sites** (server + tool-module fallbacks + the `get_nfl_database()` factory) honor it, so there's no split-brain where some paths write a different file. An explicit `db_path` (e.g. a test's temp file) still wins.

## Usage
```bash
docker volume create nfl-mcp-data
docker run -d --name nfl-mcp -p 9000:9000 \
  -e NFL_MCP_DB_PATH=/data/nfl_data.db -v nfl-mcp-data:/data \
  ghcr.io/gtonic/nfl_mcp:latest
```
A **named volume** is recommended over a host bind-mount (SQLite locking; container runs as non-root uid 1000).

## Verification
- 3 new tests (env default / explicit override / unset default); full suite **905 passed**, ruff clean.
- Verified live on a native arm64 build: DB relocates to `/data/nfl_data.db`, and a **full container destroy+recreate on the same volume** keeps the 8 MB warmed cache (no fresh re-init).

Docs: TECHNICAL.md env-table row + persistence recipe. CHANGELOG under Unreleased.