### PR TITLE
feat(sleeper): surface trending player name/position/team at top level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `uv`/`pip` resolution during the FastMCP 4 beta can't pull `httpx==1.0.dev*`
   (breaking-major dev release) or `pydantic==2.14.0a*` (alpha). `requirements.lock`
   was regenerated with `--prerelease=allow` accordingly.
+- **`get_trending_players` now surfaces `full_name`/`position`/`team` at the top
+  level of each entry, with a team fallback.** Previously the identity fields were
+  only reachable under the nested `enriched` object, so naive consumers saw bare
+  Sleeper player IDs. The three key fields are now mirrored to the top level
+  (additive — `enriched` is unchanged), and `team` falls back to the raw Sleeper
+  `team` field when the athlete cache's `team_id` column is blank (genuine free
+  agents stay `null`).
 
 ### Fixed
 - **`get_nfl_news` HTTP 403 from ESPN — branded User-Agent now identifies via a

--- a/nfl_mcp/sleeper_tools.py
+++ b/nfl_mcp/sleeper_tools.py
@@ -7,6 +7,7 @@ matchups, transactions, and more.
 """
 
 import asyncio
+import json
 import logging
 
 import httpx
@@ -73,6 +74,28 @@ def _enrich_single(nfl_db, pid, cache):
 def _enrich_id_list(nfl_db, ids):
     cache = {}
     return [_enrich_single(nfl_db, pid, cache) for pid in (ids or [])]
+
+
+def _resolve_team(base_info: dict) -> str | None:
+    """Best-effort team abbreviation for an athlete row.
+
+    Prefers the populated ``team``/``team_id`` field, then falls back to the
+    ``team`` key inside the stored raw Sleeper player JSON — the column can be
+    blank even when the raw record carries a team. Returns ``None`` for genuine
+    free agents (both sources empty).
+    """
+    team = base_info.get("team") or base_info.get("team_id")
+    if team:
+        return team
+    raw = base_info.get("raw")
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except (ValueError, TypeError):
+            raw = None
+    if isinstance(raw, dict):
+        return raw.get("team") or None
+    return None
 
 
 @handle_http_errors(
@@ -810,10 +833,20 @@ async def get_trending_players(nfl_db=None, trend_type: str = "add", lookback_ho
             except Exception as e:
                 logger.warning(f"[Trending Players] Failed to enrich player {player_id}: {e}")
 
+            # Surface the key identity fields at the top level so consumers don't
+            # have to reach into `enriched`; normalize team (the column can be
+            # blank even when the raw record carries it). `enriched` is kept
+            # intact for the full record (injury, usage, opponent, raw, ...).
+            team = _resolve_team(base_info)
+            base_info["team"] = team
+
             enriched_players.append({
                 "player_id": player_id,
                 "count": count,
-                "enriched": base_info
+                "full_name": base_info.get("full_name"),
+                "position": base_info.get("position"),
+                "team": team,
+                "enriched": base_info,
             })
 
         return create_success_response({

--- a/tests/test_sleeper_tools.py
+++ b/tests/test_sleeper_tools.py
@@ -346,6 +346,60 @@ class TestRosterAccessPermissions:
             assert result["count"] == 3  # Only valid IDs should be processed
             assert len(result["trending_players"]) == 3
 
+    @pytest.mark.asyncio
+    async def test_get_trending_players_flattens_fields_and_team_fallback(self):
+        """Top-level full_name/position/team are surfaced (additive) and team
+        falls back to the raw Sleeper `team` when the column is blank."""
+        import json as _json
+
+        func = sleeper_tools.get_trending_players
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            {'player_id': '7608', 'count': 52983},   # free agent: no team anywhere
+            {'player_id': '13413', 'count': 20130},  # blank column, raw carries team
+        ]
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+
+        athletes = {
+            '7608': {'player_id': '7608', 'full_name': 'Khalil Herbert',
+                     'position': 'RB', 'team_id': '', 'raw': _json.dumps({'team': None})},
+            '13413': {'player_id': '13413', 'full_name': 'Cyrus Allen',
+                      'position': 'WR', 'team_id': '', 'raw': _json.dumps({'team': 'KC'})},
+        }
+        fake_db = MagicMock()
+        fake_db.get_athlete_by_id.side_effect = lambda pid: athletes.get(pid)
+        fake_db.search_athletes_by_name.return_value = [{'id': 'x'}]  # non-empty -> skip fetch
+
+        with patch('nfl_mcp.sleeper_tools.create_http_client', return_value=mock_client), \
+             patch('nfl_mcp.sleeper_tools._enrich_usage_and_opponent', return_value={}), \
+             patch('nfl_mcp.nfl_tools.get_current_season_and_week',
+                   new=AsyncMock(return_value=(2026, 1))):
+            result = await func(nfl_db=fake_db, trend_type="add", limit=2)
+
+        assert result["success"] is True
+        assert result["count"] == 2
+        by_id = {p["player_id"]: p for p in result["trending_players"]}
+
+        # (a) additive top-level identity fields
+        assert by_id['7608']['full_name'] == 'Khalil Herbert'
+        assert by_id['7608']['position'] == 'RB'
+        assert by_id['7608']['count'] == 52983
+        assert by_id['13413']['full_name'] == 'Cyrus Allen'
+
+        # (b) team: genuine free agent stays None; blank column falls back to raw.team
+        assert by_id['7608']['team'] is None
+        assert by_id['13413']['team'] == 'KC'
+
+        # backward compat: nested `enriched` still present and team-normalized
+        assert by_id['13413']['enriched']['full_name'] == 'Cyrus Allen'
+        assert by_id['13413']['enriched']['team'] == 'KC'
+
 
 class TestSleeperToolsIntegration:
     """Integration tests for sleeper tools in real server context."""


### PR DESCRIPTION
## What & why

While testing the FastMCP 4 upgrade against a real Sleeper league, `get_trending_players` appeared to return bare player IDs. Root cause was that the identity fields (`full_name`/`position`/`team`) live only under the nested **`enriched`** object — the enrichment itself works correctly (the athletes cache is Sleeper-keyed). This makes the tool awkward for naive consumers.

## Changes (additive, backward-compatible)

- **(a) Top-level flattening:** each trending entry now carries `full_name`, `position`, and `team` at the top level, in addition to the unchanged nested `enriched` record (injury/usage/opponent/raw/…).
- **(b) Team fallback:** `team` resolves from the athlete cache's `team_id`; when that column is blank it falls back to the raw Sleeper `team` field. Genuine free agents stay `null`.

```
 7608  adds=52983  Khalil Herbert   RB  FA     <- free agent, correctly null
13413  adds=20130  Cyrus Allen      WR  KC
11630  adds=19224  Roman Wilson     WR  PIT
```

## Tests

- New hermetic test `test_get_trending_players_flattens_fields_and_team_fallback` covers the flattening and both team-fallback branches (blank column → `raw.team`, free agent → `None`), plus backward-compat of `enriched`.
- Full suite green: **907 passed, 2 skipped**. Ruff clean.

Note: no output field was removed or renamed — purely additive.