### PR TITLE
feat(prefetch): periodically refresh the athletes cache

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -272,12 +272,14 @@ Background data prefetching for optimal performance:
 - **Enable**: Set `NFL_MCP_PREFETCH=1`
 - **Interval**: `NFL_MCP_PREFETCH_INTERVAL` (default: 900 seconds = 15 min)
 - **Snap TTL**: `NFL_MCP_PREFETCH_SNAPS_TTL` (default: 900 seconds)
+- **Athletes refresh**: `NFL_MCP_PREFETCH_ATHLETES` (default: on) every `NFL_MCP_PREFETCH_ATHLETES_INTERVAL` (default: 86400 seconds = daily)
 
 The prefetch system automatically:
 1. Determines current season/week via NFL state
 2. Fetches team schedules (caches opponent data)
 3. Fetches player snap counts (caches usage data)
-4. Refreshes on configured intervals
+4. Refreshes the athletes cache (player names/teams/positions) at startup and daily
+5. Refreshes on configured intervals
 
 ### Robustness & Resilience
 
@@ -322,6 +324,8 @@ The server supports extensive configuration via environment variables:
 - `NFL_MCP_PREFETCH`: Enable background prefetch (0 or 1)
 - `NFL_MCP_PREFETCH_INTERVAL`: Prefetch interval in seconds (default: 900)
 - `NFL_MCP_PREFETCH_SNAPS_TTL`: Snap data TTL in seconds (default: 900)
+- `NFL_MCP_PREFETCH_ATHLETES`: Refresh athletes cache during prefetch (0 or 1, default: 1)
+- `NFL_MCP_PREFETCH_ATHLETES_INTERVAL`: Athletes refresh interval in seconds (default: 86400)
 
 #### Logging
 - `NFL_MCP_LOG_LEVEL`: Log verbosity (DEBUG, INFO, WARNING, ERROR, CRITICAL)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   User-Agent if a `403` still comes back.
 
 ### Added
+- **Periodic athletes-cache refresh in the background prefetch.** Player→team
+  assignments change over the offseason and season (signings, trades, releases),
+  which left the Sleeper athletes cache stale — e.g. trending players showing an
+  outdated team. When prefetch runs (`NFL_MCP_PREFETCH=1` + `NFL_MCP_ADVANCED_ENRICH=1`)
+  the athletes cache is now refreshed once at startup and then on a cadence
+  (default **daily**). Controlled by `NFL_MCP_PREFETCH_ATHLETES` (default on) and
+  `NFL_MCP_PREFETCH_ATHLETES_INTERVAL` (seconds, default `86400`); the refresh is
+  best-effort (failures are logged, never fatal) and its config is surfaced in the
+  `/health` `prefetch` block.
 - **Configurable database path via `NFL_MCP_DB_PATH`.** The SQLite cache path now
   falls back to the `NFL_MCP_DB_PATH` environment variable (default
   `nfl_data.db`). The default is resolved inside `NFLDatabase.__init__`, so

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -141,6 +141,8 @@ variables take precedence.
 | `NFL_MCP_PREFETCH_INTERVAL` | Prefetch interval, seconds (default 900). |
 | `NFL_MCP_PREFETCH_SNAPS_TTL` | Snap-data TTL, seconds (default 900). |
 | `NFL_MCP_PREFETCH_SCHEDULE_WEEKS` | Weeks of schedule to prefetch (default 4). |
+| `NFL_MCP_PREFETCH_ATHLETES` | `1` (default) refreshes the Sleeper athletes cache (player names/teams/positions) during prefetch — once at startup and then every interval below. `0` disables it. |
+| `NFL_MCP_PREFETCH_ATHLETES_INTERVAL` | Athletes-cache refresh interval, seconds (default 86400 = daily). |
 | `NFL_MCP_TIMEOUT_TOTAL` | Total HTTP request timeout (e.g. `45.0`). |
 | `NFL_MCP_RATE_LIMIT_DEFAULT` | Default outbound rate limit (requests/min). |
 | `NFL_MCP_NFL_NEWS_MAX` | Max NFL news items. |

--- a/nfl_mcp/health.py
+++ b/nfl_mcp/health.py
@@ -41,6 +41,10 @@ def _get_prefetch_config() -> dict[str, Any]:
         "enabled": os.getenv("NFL_MCP_PREFETCH") == "1",
         "interval_seconds": int(os.getenv("NFL_MCP_PREFETCH_INTERVAL", "900")),
         "advanced_enrich_enabled": os.getenv("NFL_MCP_ADVANCED_ENRICH") == "1",
+        "athletes_refresh_enabled": os.getenv("NFL_MCP_PREFETCH_ATHLETES", "1") == "1",
+        "athletes_refresh_interval_seconds": int(
+            os.getenv("NFL_MCP_PREFETCH_ATHLETES_INTERVAL", "86400")
+        ),
     }
 
 

--- a/nfl_mcp/server.py
+++ b/nfl_mcp/server.py
@@ -47,10 +47,52 @@ PREFETCH_ENABLED = os.getenv("NFL_MCP_PREFETCH") == "1"
 PREFETCH_INTERVAL_SECONDS = int(os.getenv("NFL_MCP_PREFETCH_INTERVAL", "900"))
 PREFETCH_SNAPS_TTL_SECONDS = int(os.getenv("NFL_MCP_PREFETCH_SNAPS_TTL", "900"))
 PREFETCH_SCHEDULE_WEEKS = int(os.getenv("NFL_MCP_PREFETCH_SCHEDULE_WEEKS", "4"))
+# Athletes cache refresh (player names/teams/positions). Enabled by default when
+# prefetch runs; refreshed once at startup and then every ATHLETES_INTERVAL.
+PREFETCH_ATHLETES = os.getenv("NFL_MCP_PREFETCH_ATHLETES", "1") == "1"
+PREFETCH_ATHLETES_INTERVAL_SECONDS = int(
+    os.getenv("NFL_MCP_PREFETCH_ATHLETES_INTERVAL", "86400")  # daily
+)
 
 # Global state for prefetch task
 _prefetch_task: asyncio.Task | None = None
 _shutdown_event: asyncio.Event | None = None
+
+
+async def _refresh_athletes(nfl_db: NFLDatabase, tag: str = "Prefetch") -> None:
+    """Refresh the Sleeper athletes cache (player names, teams, positions).
+
+    Player→team assignments change over the offseason and season (signings,
+    trades, releases), so the cache is refreshed periodically to keep enrichment
+    — e.g. trending players — current. Best-effort: failures are logged, never
+    raised. Gated by ``NFL_MCP_PREFETCH_ATHLETES`` (default on).
+    """
+    if not PREFETCH_ATHLETES:
+        return
+    try:
+        from . import athlete_tools
+        before = nfl_db.get_athlete_count()
+        res = await athlete_tools.fetch_athletes(nfl_db)
+        after = nfl_db.get_athlete_count()
+        if res.get("success"):
+            logger.info(
+                f"[{tag}] Athletes cache refreshed: {before} -> {after} "
+                f"({res.get('athletes_count')} processed)"
+            )
+        else:
+            logger.warning(f"[{tag}] Athletes refresh failed: {res.get('error')}")
+    except Exception as e:
+        logger.warning(f"[{tag}] Athletes refresh error: {e}")
+
+
+def _athletes_refresh_every_n_cycles() -> int:
+    """Number of prefetch cycles between athletes refreshes (always >= 1).
+
+    Derived from the athletes interval vs. the base prefetch interval so the
+    cadence tracks ``NFL_MCP_PREFETCH_ATHLETES_INTERVAL`` (default daily)
+    regardless of the base loop interval.
+    """
+    return max(1, round(PREFETCH_ATHLETES_INTERVAL_SECONDS / max(1, PREFETCH_INTERVAL_SECONDS)))
 
 
 async def _prefetch_loop(nfl_db: NFLDatabase, shutdown_event: asyncio.Event):
@@ -355,6 +397,11 @@ async def _prefetch_loop(nfl_db: NFLDatabase, shutdown_event: asyncio.Event):
             except Exception as e:
                 logger.warning(f"[Prefetch Cycle #{cycle_count}] Cleanup failed: {e}")
 
+        # Periodic athletes cache refresh (default daily) so player
+        # names/teams/positions stay current as roster moves happen.
+        if PREFETCH_ATHLETES and cycle_count % _athletes_refresh_every_n_cycles() == 0:
+            await _refresh_athletes(nfl_db, tag=f"Prefetch Cycle #{cycle_count}")
+
         logger.info(f"[Prefetch Cycle #{cycle_count}] Next cycle in {PREFETCH_INTERVAL_SECONDS}s")
 
         try:
@@ -489,6 +536,10 @@ def _create_prefetch_lifespan(nfl_db: NFLDatabase):
                     logger.error(
                         f"[Startup Prefetch] Failed to fetch team schedules: {e}", exc_info=True
                     )
+
+                # Initial athletes cache refresh (names/teams/positions) so
+                # enrichment is current from the first request.
+                await _refresh_athletes(nfl_db, tag="Startup Prefetch")
 
                 # Start background prefetch loop
                 _shutdown_event = asyncio.Event()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1209,3 +1209,112 @@ class TestSleeperApiToolsIntegration:
         app = create_app()
         assert app.name == "NFL MCP Server"
         # Test passes if no exceptions are raised during app creation
+
+
+class TestAthletesRefresh:
+    """Tests for the periodic athletes-cache refresh in the prefetch loop."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_athletes_calls_fetch_when_enabled(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from nfl_mcp import server
+
+        calls = {}
+
+        async def fake_fetch(db):
+            calls["db"] = db
+            return {"success": True, "error": None, "athletes_count": 10}
+
+        fake_db = MagicMock()
+        fake_db.get_athlete_count.side_effect = [100, 110]
+
+        monkeypatch.setattr(server, "PREFETCH_ATHLETES", True)
+        monkeypatch.setattr("nfl_mcp.athlete_tools.fetch_athletes", fake_fetch)
+
+        await server._refresh_athletes(fake_db, tag="Test")
+        assert calls.get("db") is fake_db
+
+    @pytest.mark.asyncio
+    async def test_refresh_athletes_skipped_when_disabled(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from nfl_mcp import server
+
+        called = {"v": False}
+
+        async def fake_fetch(db):
+            called["v"] = True
+            return {"success": True}
+
+        monkeypatch.setattr(server, "PREFETCH_ATHLETES", False)
+        monkeypatch.setattr("nfl_mcp.athlete_tools.fetch_athletes", fake_fetch)
+
+        await server._refresh_athletes(MagicMock(), tag="Test")
+        assert called["v"] is False
+
+    @pytest.mark.asyncio
+    async def test_refresh_athletes_swallows_errors(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from nfl_mcp import server
+
+        async def boom(db):
+            raise RuntimeError("network down")
+
+        fake_db = MagicMock()
+        fake_db.get_athlete_count.return_value = 0
+
+        monkeypatch.setattr(server, "PREFETCH_ATHLETES", True)
+        monkeypatch.setattr("nfl_mcp.athlete_tools.fetch_athletes", boom)
+
+        # Best-effort: must not raise
+        await server._refresh_athletes(fake_db, tag="Test")
+
+    def test_athletes_refresh_every_n_cycles(self, monkeypatch):
+        from nfl_mcp import server
+
+        # daily refresh at a 15-minute base cycle -> every 96 cycles
+        monkeypatch.setattr(server, "PREFETCH_INTERVAL_SECONDS", 900)
+        monkeypatch.setattr(server, "PREFETCH_ATHLETES_INTERVAL_SECONDS", 86400)
+        assert server._athletes_refresh_every_n_cycles() == 96
+
+        # never zero, even if the athletes interval is below the base interval
+        monkeypatch.setattr(server, "PREFETCH_ATHLETES_INTERVAL_SECONDS", 100)
+        assert server._athletes_refresh_every_n_cycles() == 1
+
+    @pytest.mark.asyncio
+    async def test_startup_prefetch_triggers_athletes_refresh(self, monkeypatch):
+        """The startup lifespan warm-up invokes the athletes refresh."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from nfl_mcp import server, sleeper_tools
+
+        # Enable the prefetch startup path without touching the environment.
+        monkeypatch.setattr(server, "PREFETCH_ENABLED", True)
+        monkeypatch.setattr(sleeper_tools, "ADVANCED_ENRICH_ENABLED", True)
+        # Reset (and auto-restore) the task globals the lifespan mutates.
+        monkeypatch.setattr(server, "_prefetch_task", None)
+        monkeypatch.setattr(server, "_shutdown_event", None)
+
+        # Fast, network-free stubs for the schedule warm-up + background loop.
+        monkeypatch.setattr(
+            sleeper_tools, "get_nfl_state",
+            AsyncMock(return_value={"success": True, "nfl_state": {"season": "2026"}}),
+        )
+        monkeypatch.setattr(sleeper_tools, "_fetch_all_team_schedules", AsyncMock(return_value=[]))
+        monkeypatch.setattr(server, "_prefetch_loop", AsyncMock())
+
+        refresh = AsyncMock()
+        monkeypatch.setattr(server, "_refresh_athletes", refresh)
+
+        lifespan = server._create_prefetch_lifespan(MagicMock())
+        async with lifespan(MagicMock()):
+            pass  # run startup, then shutdown
+
+        assert refresh.await_count >= 1
+        tags = [
+            (c.kwargs.get("tag") or (c.args[1] if len(c.args) > 1 else None))
+            for c in refresh.await_args_list
+        ]
+        assert "Startup Prefetch" in tags


### PR DESCRIPTION
## What & why

Follow-up to #137. Player→team assignments change over the offseason and season (signings, trades, releases), so the local Sleeper **athletes cache** goes stale — e.g. a trending player showing an outdated team (Khalil Herbert surfaced as a free agent until a manual refresh showed he'd signed with SF). Previously the athletes cache was only (re)loaded on demand when empty.

This wires an athletes refresh into the existing background prefetch: **once at startup, then on a cadence (default daily).**

## Changes

- **`server.py`**
  - `_refresh_athletes(nfl_db, tag)` — best-effort refresh via `athlete_tools.fetch_athletes` (logs before→after counts; failures logged, never fatal). Gated by `NFL_MCP_PREFETCH_ATHLETES` (default **on**).
  - `_athletes_refresh_every_n_cycles()` — derives the loop cadence from `NFL_MCP_PREFETCH_ATHLETES_INTERVAL` (default `86400`s = daily) vs. the base prefetch interval (always ≥ 1).
  - Called from the **startup warm-up** and periodically in `_prefetch_loop` (alongside the existing schedule/snaps prefetch; same `NFL_MCP_PREFETCH=1` + `NFL_MCP_ADVANCED_ENRICH=1` gating).
- **`health.py`** — `/health` `prefetch` block now reports `athletes_refresh_enabled` and `athletes_refresh_interval_seconds`.
- **docs** — new env vars documented in `TECHNICAL.md` + `AGENT.md`.

## New env vars

| Var | Default | Meaning |
|---|---|---|
| `NFL_MCP_PREFETCH_ATHLETES` | `1` | Refresh athletes cache during prefetch |
| `NFL_MCP_PREFETCH_ATHLETES_INTERVAL` | `86400` | Refresh cadence, seconds (daily) |

## Tests

- `TestAthletesRefresh`: enabled→calls fetch, disabled→skips, errors are swallowed, cadence formula (96 cycles/day at 15-min base; never zero), and an integration test that the **startup lifespan actually triggers** the refresh (network-free stubs).
- Full suite green: **912 passed, 2 skipped**. Ruff clean.