### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-05
+
 ### Changed
 - **Upgraded to FastMCP 4 (`>=4.0.0b1`) and moved the HTTP transport to stateless
   MCP (the sessionless `2026-07-28` protocol).** FastMCP 4 rebuilds on MCP Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfl_mcp"
-version = "0.6.7"
+version = "0.7.0"
 description = "NFL MCP Server - Fantasy Football Analysis via Model Context Protocol"
 authors = [{name = "gtonic", email = "tom.geiger@alp54.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
Release **0.7.0** (from current `main`). Bumps `pyproject.toml` and rolls the `CHANGELOG.md` `[Unreleased]` section into `## [0.7.0] - 2026-08-05`.

## Highlights
- **FastMCP 4 + stateless MCP transport** (#136): upgraded to `fastmcp>=4.0.0b1` (MCP Python SDK v2); the HTTP transport now serves the sessionless `2026-07-28` protocol with `stateless_http` enabled (no `Mcp-Session-Id`, scales behind a round-robin LB). `NFL_MCP_STATELESS_HTTP=0` reverts to sessions.
- **Trending players surface name/position/team at top level** (#137), with a team fallback to the raw Sleeper record.
- **Periodic athletes-cache refresh in prefetch** (#138): startup + daily, keeps player→team current. Env: `NFL_MCP_PREFETCH_ATHLETES`, `NFL_MCP_PREFETCH_ATHLETES_INTERVAL`.
- **Configurable DB path** via `NFL_MCP_DB_PATH`.
- **Fix:** `get_nfl_news` ESPN `403` — branded User-Agent identifies via project URL (#135).

## Notes
- `fastmcp 4.0.0b1` is a beta; `httpx<1` / `pydantic<2.14` bounds keep resolution stable.
- Merging + tagging `v0.7.0` triggers the CI **Build & publish image** job to push `ghcr.io/gtonic/nfl_mcp:0.7.0`.

Diff is release-only: `pyproject.toml` version + `CHANGELOG.md` heading.