### PR TITLE
fix(espn): injuries + coaching data (refs, head coach, coordinators)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (body part), `description`, `return_date` and a fantasy `severity`. Inline
   responses are still handled (back-compat), and "Injured Reserve" now maps to
   `High` severity.
-- **`get_coaching_staff` resolves the head coach instead of returning nulls.**
+- **`get_coaching_staff` now resolves the head coach and fills in coordinators.**
   The ESPN coach object has no `displayName`/`position`, so the coach name came
-  back empty and no head coach was identified. The name is now built from
-  `firstName`/`lastName`, and the coach returned by ESPN's team `/coaches`
-  endpoint (which exposes only the head coach) is promoted to `head_coach`. A
-  `note` field now states explicitly that coordinators/position coaches are not
-  available from this endpoint, instead of silently returning nulls.
+  back empty and no head coach was identified; the name is now built from
+  `firstName`/`lastName` and the coach returned by ESPN's team `/coaches`
+  endpoint (which exposes only the head coach) is promoted to `head_coach`.
+  Because ESPN never exposes coordinators, `offensive_coordinator` /
+  `defensive_coordinator` are now enriched **best-effort from the Wikipedia
+  season-page infobox** (`off_coach`/`def_coach`) — with a `coordinator_source`
+  field and an honest `note` about the partial coverage. Adds an optional
+  `season` argument (defaults to the current NFL season).
+- **`get_all_coaching_staffs` now returns head coaches (was 0/32).** The coaches
+  URL was built as `f"{team_url}/coaches"` where `team_url` already carried a
+  `?lang=…` query string, producing a broken URL (`…?lang=…/coaches`), so every
+  team came back `head_coach: null, coach_count: 0`. The URL is now built from
+  the numeric team id and the head-coach name is resolved from `firstName`/
+  `lastName`.
 
 ## [0.7.0] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`get_team_injuries` now returns real injury data (names, status, body part,
+  return date).** ESPN's Core API returns the team injury list as bare
+  `{"$ref": …}` links; the tool treated each item as a complete object, so every
+  field came back empty (`player_name: null`, `status: "Unknown"`). It now
+  follows both hops — the injury ref and the nested athlete ref — concurrently
+  (bounded fan-out), and surfaces `player_name`, `position`, `status`, `type`
+  (body part), `description`, `return_date` and a fantasy `severity`. Inline
+  responses are still handled (back-compat), and "Injured Reserve" now maps to
+  `High` severity.
+- **`get_coaching_staff` resolves the head coach instead of returning nulls.**
+  The ESPN coach object has no `displayName`/`position`, so the coach name came
+  back empty and no head coach was identified. The name is now built from
+  `firstName`/`lastName`, and the coach returned by ESPN's team `/coaches`
+  endpoint (which exposes only the head coach) is promoted to `head_coach`. A
+  `note` field now states explicitly that coordinators/position coaches are not
+  available from this endpoint, instead of silently returning nulls.
+
 ## [0.7.0] - 2026-08-05
 
 ### Changed

--- a/nfl_mcp/coaching_tools.py
+++ b/nfl_mcp/coaching_tools.py
@@ -6,6 +6,7 @@ coach records, and coaching tree information from ESPN API.
 """
 
 import logging
+import re
 from typing import Any
 
 import httpx
@@ -89,19 +90,109 @@ def _classify_coach_role(role_name: str) -> dict[str, Any]:
         return {"category": "assistant", "side": "unknown", "is_coordinator": False}
 
 
+# ESPN abbreviation -> Wikipedia team name, used to look up "{season} {name} season"
+# for coordinator info (ESPN exposes only the head coach; see below).
+TEAM_WIKI_NAMES = {
+    "ARI": "Arizona Cardinals", "ATL": "Atlanta Falcons", "BAL": "Baltimore Ravens",
+    "BUF": "Buffalo Bills", "CAR": "Carolina Panthers", "CHI": "Chicago Bears",
+    "CIN": "Cincinnati Bengals", "CLE": "Cleveland Browns", "DAL": "Dallas Cowboys",
+    "DEN": "Denver Broncos", "DET": "Detroit Lions", "GB": "Green Bay Packers",
+    "HOU": "Houston Texans", "IND": "Indianapolis Colts", "JAX": "Jacksonville Jaguars",
+    "KC": "Kansas City Chiefs", "LV": "Las Vegas Raiders", "LAC": "Los Angeles Chargers",
+    "LAR": "Los Angeles Rams", "MIA": "Miami Dolphins", "MIN": "Minnesota Vikings",
+    "NE": "New England Patriots", "NO": "New Orleans Saints", "NYG": "New York Giants",
+    "NYJ": "New York Jets", "PHI": "Philadelphia Eagles", "PIT": "Pittsburgh Steelers",
+    "SF": "San Francisco 49ers", "SEA": "Seattle Seahawks", "TB": "Tampa Bay Buccaneers",
+    "TEN": "Tennessee Titans", "WAS": "Washington Commanders", "WSH": "Washington Commanders",
+}
+
+_WIKI_UA = "nfl-mcp/1.0 (+https://github.com/gtonic/nfl_mcp) coaching-staff enrichment"
+
+
+def _current_nfl_season() -> int:
+    """Best-effort current NFL season year (league year rolls over in March)."""
+    from datetime import UTC, datetime
+    now = datetime.now(UTC)
+    return now.year if now.month >= 3 else now.year - 1
+
+
+def _infobox_field(wikitext: str, field: str) -> str | None:
+    """Return the raw value of a top-level infobox `| field = ...` line."""
+    m = re.search(r'\|\s*' + re.escape(field) + r'\s*=\s*([^\n|]*)', wikitext)
+    return m.group(1) if m else None
+
+
+def _strip_wikitext(val: str | None) -> str | None:
+    """Reduce an infobox value to a plain name (strip links/refs/templates)."""
+    if not val:
+        return None
+    val = re.sub(r'<ref.*?</ref>', '', val, flags=re.S)
+    val = re.sub(r'<ref[^>]*/>', '', val)
+    val = re.split(r'<br\s*/?>', val)[0]              # first entry if a <br> list
+    val = re.sub(r'\[\[(?:[^\]|]+\|)?([^\]]+)\]\]', r'\1', val)  # [[Link|Text]] -> Text
+    val = re.sub(r'\{\{[^{}]*\}\}', '', val)          # drop simple templates
+    val = val.replace("'''", "").replace("''", "").strip()
+    return val or None
+
+
+async def _fetch_coordinators_wikipedia(client, team_abbrev: str, season: int) -> dict:
+    """Best-effort OC/DC lookup from the Wikipedia 'Infobox NFL team season'.
+
+    ESPN does not expose coordinators, so we read ``off_coach``/``def_coach``
+    from the team's season page. Coverage is partial — many pages only fill the
+    head coach — so this returns ``{}`` when nothing usable is found, and never
+    raises (the caller degrades gracefully).
+    """
+    name = TEAM_WIKI_NAMES.get(team_abbrev.upper())
+    if not name:
+        return {}
+    # Try the requested season, then the prior one (new-season pages can lag).
+    for yr in (season, season - 1):
+        title = f"{yr} {name} season"
+        try:
+            resp = await client.get(
+                "https://en.wikipedia.org/w/api.php",
+                params={
+                    "action": "query", "prop": "revisions", "rvprop": "content",
+                    "rvslots": "main", "format": "json", "redirects": 1, "titles": title,
+                },
+                headers={"User-Agent": _WIKI_UA},
+            )
+            resp.raise_for_status()
+            page = next(iter(resp.json()["query"]["pages"].values()))
+            if "revisions" not in page:
+                continue
+            wt = page["revisions"][0]["slots"]["main"]["*"]
+            oc = _strip_wikitext(_infobox_field(wt, "off_coach"))
+            dc = _strip_wikitext(_infobox_field(wt, "def_coach"))
+            if oc or dc:
+                return {
+                    "offensive_coordinator": oc,
+                    "defensive_coordinator": dc,
+                    "source": "wikipedia",
+                    "season": yr,
+                    "page": page.get("title"),
+                }
+        except Exception as e:  # best-effort — never fail the coaching call
+            logger.debug(f"[Coaching] Wikipedia coordinator lookup failed ({title}): {e}")
+    return {}
+
+
 @handle_http_errors(
     default_data={"team_id": None, "team_name": None, "coaches": [], "head_coach": None},
     operation_name="fetching coaching staff"
 )
-async def get_coaching_staff(team_id: str) -> dict:
+async def get_coaching_staff(team_id: str, season: int | None = None) -> dict:
     """
-    Get the coaching staff for a specific NFL team from ESPN API.
+    Get the coaching staff for a specific NFL team.
 
-    This tool fetches coaching information including head coach, coordinators,
-    and position coaches from ESPN's Core API.
+    The head coach comes from ESPN's Core API (the only coach ESPN exposes).
+    Coordinators are enriched best-effort from the Wikipedia season-page infobox
+    (``off_coach``/``def_coach``) — coverage is partial, so they may be null.
 
     Args:
         team_id: The team abbreviation (e.g., 'KC', 'TB', 'NE') or ESPN team ID
+        season: Season year for the coordinator lookup (defaults to current)
 
     Returns:
         A dictionary containing:
@@ -109,8 +200,10 @@ async def get_coaching_staff(team_id: str) -> dict:
         - team_name: The team's full name
         - coaches: List of all coaches with roles and details
         - head_coach: The head coach information (convenience field)
-        - offensive_coordinator: The OC information if available
-        - defensive_coordinator: The DC information if available
+        - offensive_coordinator: The OC information if available (else None)
+        - defensive_coordinator: The DC information if available (else None)
+        - coordinator_source: Source of the coordinators (e.g. "wikipedia")
+        - note: Provenance / coverage note
         - success: Whether the request was successful
         - error: Error message (if any)
         - error_type: Type of error (if any)
@@ -224,13 +317,39 @@ async def get_coaching_staff(team_id: str) -> dict:
                 coaches[0]["role"] = "Head Coach"
             head_coach = coaches[0]
 
-        # Be explicit that coordinators / position coaches are not available from
-        # this endpoint (so callers don't read the nulls as "team has none").
-        note = None
+        # ESPN exposes only the head coach. Coordinators (when available) come
+        # from the Wikipedia season-page infobox — best-effort, partial coverage.
+        coordinator_source = None
         if offensive_coordinator is None and defensive_coordinator is None:
+            wiki_season = season or _current_nfl_season()
+            coords = await _fetch_coordinators_wikipedia(client, team_id_upper, wiki_season)
+            if coords.get("offensive_coordinator"):
+                offensive_coordinator = {
+                    "name": coords["offensive_coordinator"], "role": "Offensive Coordinator",
+                    "category": "coordinator", "side": "offense", "is_coordinator": True,
+                    "source": "wikipedia",
+                }
+                coaches.append(offensive_coordinator)
+            if coords.get("defensive_coordinator"):
+                defensive_coordinator = {
+                    "name": coords["defensive_coordinator"], "role": "Defensive Coordinator",
+                    "category": "coordinator", "side": "defense", "is_coordinator": True,
+                    "source": "wikipedia",
+                }
+                coaches.append(defensive_coordinator)
+            if coords:
+                coordinator_source = coords.get("source")
+
+        # Honest note about data provenance / gaps.
+        if offensive_coordinator is not None or defensive_coordinator is not None:
             note = (
-                "ESPN's core API exposes only the head coach for a team; "
-                "coordinators and position coaches are not available from this endpoint."
+                "Head coach is from ESPN; coordinators are best-effort from the "
+                "Wikipedia season-page infobox (coverage is partial)."
+            )
+        else:
+            note = (
+                "ESPN exposes only the head coach; no coordinators were found for "
+                "this team (the Wikipedia season-page infobox had none)."
             )
 
         return create_success_response({
@@ -240,6 +359,7 @@ async def get_coaching_staff(team_id: str) -> dict:
             "head_coach": head_coach,
             "offensive_coordinator": offensive_coordinator,
             "defensive_coordinator": defensive_coordinator,
+            "coordinator_source": coordinator_source,
             "total_coaches": len(coaches),
             "note": note
         })
@@ -291,8 +411,13 @@ async def get_all_coaching_staffs() -> dict:
                 team_id = team_info.get('abbreviation', team_info.get('id', ''))
                 team_name = team_info.get('displayName', team_info.get('name', ''))
 
-                # Fetch coaches for this team
-                coaches_url = f"{team_url}/coaches"
+                # Fetch coaches for this team. Build the URL from the numeric id:
+                # team_url carries a query string, so f"{team_url}/coaches" puts
+                # `/coaches` *after* the `?...` and yields a broken URL.
+                coaches_url = (
+                    "https://sports.core.api.espn.com/v2/sports/football/leagues/nfl/"
+                    f"teams/{team_info.get('id')}/coaches"
+                )
                 try:
                     coaches_response = await client.get(coaches_url, headers=headers)
                     coaches_response.raise_for_status()
@@ -301,20 +426,30 @@ async def get_all_coaching_staffs() -> dict:
                     coach_refs = coaches_data.get('items', [])
                     head_coach_name = None
 
-                    # Get head coach name
-                    for coach_ref in coach_refs[:5]:  # Check first 5 coaches
+                    # This endpoint exposes the head coach; the coach object often
+                    # lacks `position`/`displayName`, so take the first coach and
+                    # build the name from first/last.
+                    for coach_ref in coach_refs[:5]:
                         ref_url = coach_ref.get('$ref', '')
-                        if ref_url:
-                            try:
-                                coach_response = await client.get(ref_url, headers=headers)
-                                coach_response.raise_for_status()
-                                coach_data = coach_response.json()
-                                role = coach_data.get('position', {}).get('name', '').lower()
-                                if 'head coach' in role:
-                                    head_coach_name = coach_data.get('displayName', coach_data.get('fullName', ''))
-                                    break
-                            except Exception:
-                                continue
+                        if not ref_url:
+                            continue
+                        try:
+                            coach_response = await client.get(ref_url, headers=headers)
+                            coach_response.raise_for_status()
+                            coach_data = coach_response.json()
+                        except Exception:
+                            continue
+                        role = (coach_data.get('position') or {}).get('name', '').lower()
+                        name = (
+                            coach_data.get('displayName')
+                            or coach_data.get('fullName')
+                            or " ".join(p for p in (coach_data.get('firstName'),
+                                                    coach_data.get('lastName')) if p)
+                        )
+                        if 'head coach' in role or head_coach_name is None:
+                            head_coach_name = name
+                        if 'head coach' in role:
+                            break
 
                     all_teams.append({
                         "team_id": team_id,

--- a/nfl_mcp/coaching_tools.py
+++ b/nfl_mcp/coaching_tools.py
@@ -171,10 +171,16 @@ async def get_coaching_staff(team_id: str) -> dict:
                     # Extract coach info
                     coach_info = {
                         "id": coach_data.get('id', ''),
-                        "name": coach_data.get('displayName', coach_data.get('fullName', '')),
+                        "name": (
+                            coach_data.get('displayName')
+                            or coach_data.get('fullName')
+                            or " ".join(
+                                p for p in (coach_data.get('firstName'), coach_data.get('lastName')) if p
+                            )
+                        ),
                         "first_name": coach_data.get('firstName', ''),
                         "last_name": coach_data.get('lastName', ''),
-                        "role": coach_data.get('position', {}).get('name', 'Unknown'),
+                        "role": (coach_data.get('position') or {}).get('name', 'Unknown'),
                         "experience": coach_data.get('experience', None),
                     }
 
@@ -208,6 +214,25 @@ async def get_coaching_staff(team_id: str) -> dict:
                     logger.warning(f"Failed to fetch coach details from {ref_url}: {e}")
                     continue
 
+        # ESPN's core `/teams/{id}/coaches` endpoint exposes only the head coach,
+        # and the coach object carries no `position` field — so role-based
+        # classification finds no head coach. Promote the (single) returned coach
+        # so `head_coach` is populated instead of null.
+        if head_coach is None and coaches:
+            coaches[0].update({"category": "head_coach", "side": "both", "is_coordinator": False})
+            if not coaches[0].get("role") or coaches[0]["role"] == "Unknown":
+                coaches[0]["role"] = "Head Coach"
+            head_coach = coaches[0]
+
+        # Be explicit that coordinators / position coaches are not available from
+        # this endpoint (so callers don't read the nulls as "team has none").
+        note = None
+        if offensive_coordinator is None and defensive_coordinator is None:
+            note = (
+                "ESPN's core API exposes only the head coach for a team; "
+                "coordinators and position coaches are not available from this endpoint."
+            )
+
         return create_success_response({
             "team_id": team_id_upper,
             "team_name": team_name,
@@ -215,7 +240,8 @@ async def get_coaching_staff(team_id: str) -> dict:
             "head_coach": head_coach,
             "offensive_coordinator": offensive_coordinator,
             "defensive_coordinator": defensive_coordinator,
-            "total_coaches": len(coaches)
+            "total_coaches": len(coaches),
+            "note": note
         })
 
 

--- a/nfl_mcp/nfl_tools.py
+++ b/nfl_mcp/nfl_tools.py
@@ -411,53 +411,101 @@ async def get_team_injuries(team_id: str, limit: int | None = 50) -> dict:
             else:
                 raise  # Re-raise other HTTP errors
 
-        # Parse JSON response
+        # Parse JSON response. The Core API returns a paginated list where each
+        # item is a bare {"$ref": ...} pointing at the injury object, which in
+        # turn references the athlete via another {"$ref": ...}. Follow both hops.
+        # (Older/mocked responses may inline the objects — handle that too.)
         data = response.json()
+        injury_items = data.get('items', [])
 
-        # Extract injuries from the response
-        injuries_data = data.get('items', [])
+        async def _resolve_injury(item):
+            # Dereference the injury object unless it's already inlined.
+            detail = item
+            ref = item.get('$ref') if isinstance(item, dict) else None
+            if ref and not (isinstance(item, dict) and item.get('status')):
+                try:
+                    r = await client.get(ref, headers=headers)
+                    r.raise_for_status()
+                    detail = r.json()
+                except Exception as e:
+                    logger.debug(f"[Injuries] injury ref fetch failed ({ref}): {e}")
+                    return None
 
-        # Process injuries to extract relevant information
-        processed_injuries = []
-        team_name = None
+            # Athlete: dereference when given as a $ref, else read inline.
+            athlete = detail.get('athlete', {}) or {}
+            a_ref = athlete.get('$ref') if isinstance(athlete, dict) else None
+            if a_ref:
+                try:
+                    ar = await client.get(a_ref, headers=headers)
+                    ar.raise_for_status()
+                    athlete = ar.json()
+                except Exception as e:
+                    logger.debug(f"[Injuries] athlete ref fetch failed ({a_ref}): {e}")
+                    athlete = {}
+            player_name = (
+                athlete.get('displayName')
+                or f"{athlete.get('firstName', '')} {athlete.get('lastName', '')}".strip()
+                or 'Unknown'
+            )
+            player_id = athlete.get('id')
+            position = (athlete.get('position') or {}).get('abbreviation', 'N/A')
 
-        for injury_item in injuries_data:
-            injury = {}
+            # Status may be a plain string (Core API) or a {"name": ...} dict.
+            status = detail.get('status')
+            if isinstance(status, dict):
+                status = status.get('name') or status.get('description')
+            type_obj = detail.get('type') or {}
+            if not status and isinstance(type_obj, dict):
+                status = type_obj.get('description')
+            status = status or 'Unknown'
 
-            # Get athlete information
-            athlete_ref = injury_item.get('athlete', {})
-            if athlete_ref and isinstance(athlete_ref, dict):
-                injury['player_name'] = athlete_ref.get('displayName', 'Unknown')
-                injury['player_id'] = athlete_ref.get('id')
-                injury['position'] = athlete_ref.get('position', {}).get('abbreviation', 'N/A')
+            # `details` carries the body part / specifics; the top-level `type`
+            # is the status classification, not the body part.
+            details = detail.get('details') or {}
+            body_part = details.get('type')
+            specifics = details.get('detail')
+            description = (
+                detail.get('shortComment')
+                or detail.get('description')
+                or " - ".join(p for p in (body_part, specifics) if p)
+                or 'No description available'
+            )
 
-            # Get team information (should be consistent across all items)
-            if not team_name:
-                team_ref = injury_item.get('team', {})
-                if team_ref and isinstance(team_ref, dict):
-                    team_name = team_ref.get('displayName', 'Unknown Team')
-
-            # Get injury details
-            injury['status'] = injury_item.get('status', {}).get('name', 'Unknown')
-            injury['description'] = injury_item.get('description', 'No description available')
-            injury['date'] = injury_item.get('date', 'Unknown')
-            injury['type'] = injury_item.get('type', {}).get('name', 'Unknown')
-
-            # Fantasy relevance indicators
-            injury['severity'] = 'Unknown'
-            status_lower = injury['status'].lower()
-            if 'out' in status_lower or 'ir' in status_lower:
-                injury['severity'] = 'High'
+            severity = 'Unknown'
+            status_lower = status.lower()
+            if 'out' in status_lower or 'reserve' in status_lower or status_lower == 'ir':
+                severity = 'High'
             elif 'doubtful' in status_lower or 'questionable' in status_lower:
-                injury['severity'] = 'Medium'
+                severity = 'Medium'
             elif 'probable' in status_lower or 'limited' in status_lower:
-                injury['severity'] = 'Low'
+                severity = 'Low'
 
-            processed_injuries.append(injury)
+            return {
+                'player_id': player_id,
+                'player_name': player_name,
+                'position': position,
+                'status': status,
+                'type': body_part or 'Unknown',
+                'description': description,
+                'return_date': details.get('returnDate'),
+                'date': detail.get('date', 'Unknown'),
+                'severity': severity,
+            }
+
+        # Resolve refs concurrently, but bound fan-out to stay a good API
+        # citizen (each injury can trigger up to two follow-up requests).
+        sem = asyncio.Semaphore(10)
+
+        async def _bounded(item):
+            async with sem:
+                return await _resolve_injury(item)
+
+        resolved = await asyncio.gather(*[_bounded(it) for it in injury_items])
+        processed_injuries = [inj for inj in resolved if inj]
 
         return create_success_response({
             "team_id": team_id_upper,
-            "team_name": team_name,
+            "team_name": None,
             "injuries": processed_injuries,
             "count": len(processed_injuries),
             "cache_source": "api"

--- a/tests/test_coaching_tools.py
+++ b/tests/test_coaching_tools.py
@@ -314,8 +314,10 @@ class TestGetCoachingStaffResolution:
         }
 
         async def fake_get(url, headers=None, **kwargs):
-            if url.endswith("/coaches"):  # the team coaches list endpoint
+            if url.endswith("/coaches"):       # the team coaches list endpoint
                 return responses["LIST"]
+            if "wikipedia.org" in url:         # no season page -> no coordinators
+                return make({"query": {"pages": {"-1": {"missing": ""}}}})
             return responses[url]
 
         mock_client = AsyncMock()
@@ -324,7 +326,7 @@ class TestGetCoachingStaffResolution:
         mock_client.__aexit__ = AsyncMock(return_value=None)
 
         with patch('nfl_mcp.coaching_tools.create_http_client', return_value=mock_client):
-            result = await get_coaching_staff("SF")
+            result = await get_coaching_staff("SF", season=2026)
 
         assert result["success"] is True
         hc = result["head_coach"]
@@ -333,7 +335,62 @@ class TestGetCoachingStaffResolution:
         assert hc["category"] == "head_coach"          # promoted despite missing position
         assert hc["role"] == "Head Coach"
         assert result["team_name"] == "San Francisco 49ers"
-        # ESPN exposes only the HC here -> coordinators null, with an explicit note.
+        # No coordinators in the (missing) Wikipedia page -> null, with a note.
         assert result["offensive_coordinator"] is None
         assert result["defensive_coordinator"] is None
         assert result.get("note")
+
+    @pytest.mark.asyncio
+    async def test_enriches_coordinators_from_wikipedia(self):
+        coach_ref = "http://espn/v2/nfl/coaches/17533"
+        team_ref = "http://espn/v2/nfl/teams/25"
+
+        def make(payload):
+            m = MagicMock()
+            m.status_code = 200
+            m.json.return_value = payload
+            m.raise_for_status = MagicMock()
+            return m
+
+        wiki_wt = (
+            "{{Infobox NFL team season\n"
+            "| coach = [[Kyle Shanahan]]\n"
+            "| off_coach = [[Klay Kubiak]]\n"
+            "| def_coach = Raheem Morris\n"
+            "}}"
+        )
+        responses = {
+            "LIST": make({"count": 1, "items": [{"$ref": coach_ref}]}),
+            coach_ref: make({"id": "17533", "firstName": "Kyle", "lastName": "Shanahan",
+                             "experience": 9, "team": {"$ref": team_ref}}),
+            team_ref: make({"displayName": "San Francisco 49ers"}),
+            "WIKI": make({"query": {"pages": {"1": {
+                "title": "2026 San Francisco 49ers season",
+                "revisions": [{"slots": {"main": {"*": wiki_wt}}}]}}}}),
+        }
+
+        async def fake_get(url, headers=None, **kwargs):
+            if url.endswith("/coaches"):
+                return responses["LIST"]
+            if "wikipedia.org" in url:
+                return responses["WIKI"]
+            return responses[url]
+
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = fake_get
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch('nfl_mcp.coaching_tools.create_http_client', return_value=mock_client):
+            result = await get_coaching_staff("SF", season=2026)
+
+        assert result["success"] is True
+        assert result["head_coach"]["name"] == "Kyle Shanahan"
+        oc = result["offensive_coordinator"]
+        dc = result["defensive_coordinator"]
+        assert oc["name"] == "Klay Kubiak"     # [[link]] stripped
+        assert oc["source"] == "wikipedia"
+        assert oc["category"] == "coordinator"
+        assert dc["name"] == "Raheem Morris"
+        assert result["coordinator_source"] == "wikipedia"
+        assert result["total_coaches"] == 3    # HC + OC + DC

--- a/tests/test_coaching_tools.py
+++ b/tests/test_coaching_tools.py
@@ -289,3 +289,51 @@ class TestConstants:
         for _team_id, scheme_data in TEAM_SCHEMES.items():
             assert "offense" in scheme_data
             assert "defense" in scheme_data
+
+
+class TestGetCoachingStaffResolution:
+    """The ESPN coach object has no displayName/position; resolve HC anyway."""
+
+    @pytest.mark.asyncio
+    async def test_resolves_head_coach_without_position_field(self):
+        coach_ref = "http://espn/v2/nfl/coaches/17533"
+        team_ref = "http://espn/v2/nfl/teams/25"
+
+        def make(payload):
+            m = MagicMock()
+            m.status_code = 200
+            m.json.return_value = payload
+            m.raise_for_status = MagicMock()
+            return m
+
+        responses = {
+            "LIST": make({"count": 1, "items": [{"$ref": coach_ref}]}),
+            coach_ref: make({"id": "17533", "firstName": "Kyle", "lastName": "Shanahan",
+                             "experience": 9, "team": {"$ref": team_ref}}),
+            team_ref: make({"displayName": "San Francisco 49ers"}),
+        }
+
+        async def fake_get(url, headers=None, **kwargs):
+            if url.endswith("/coaches"):  # the team coaches list endpoint
+                return responses["LIST"]
+            return responses[url]
+
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = fake_get
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch('nfl_mcp.coaching_tools.create_http_client', return_value=mock_client):
+            result = await get_coaching_staff("SF")
+
+        assert result["success"] is True
+        hc = result["head_coach"]
+        assert hc is not None
+        assert hc["name"] == "Kyle Shanahan"          # built from first+last (no displayName)
+        assert hc["category"] == "head_coach"          # promoted despite missing position
+        assert hc["role"] == "Head Coach"
+        assert result["team_name"] == "San Francisco 49ers"
+        # ESPN exposes only the HC here -> coordinators null, with an explicit note.
+        assert result["offensive_coordinator"] is None
+        assert result["defensive_coordinator"] is None
+        assert result.get("note")

--- a/tests/test_nfl_tools.py
+++ b/tests/test_nfl_tools.py
@@ -235,6 +235,57 @@ class TestGetTeamInjuries:
         result = await get_team_injuries("")
         assert result["success"] is False
 
+    @pytest.mark.asyncio
+    async def test_get_team_injuries_dereferences_refs(self):
+        """Core-API items are bare $refs; the tool must follow injury + athlete refs."""
+        inj_ref = "http://espn/v2/nfl/seasons/2026/athletes/9/injuries/1"
+        ath_ref = "http://espn/v2/nfl/seasons/2026/athletes/9"
+
+        def make(payload):
+            m = MagicMock()
+            m.status_code = 200
+            m.json.return_value = payload
+            m.raise_for_status = MagicMock()
+            return m
+
+        responses = {
+            "LIST": make({"count": 1, "items": [{"$ref": inj_ref}]}),
+            inj_ref: make({
+                "status": "Questionable",
+                "date": "2026-08-10",
+                "athlete": {"$ref": ath_ref},
+                "type": {"name": "INJURY_STATUS_QUESTIONABLE",
+                         "description": "questionable", "abbreviation": "Q"},
+                "details": {"type": "Hamstring", "detail": "Soreness", "returnDate": "2026-08-13"},
+                "shortComment": "Dealing with a hamstring issue.",
+            }),
+            ath_ref: make({"id": "9", "displayName": "De'Zhaun Stribling",
+                           "position": {"abbreviation": "WR"}}),
+        }
+
+        async def fake_get(url, headers=None, **kwargs):
+            if "/injuries?" in url:  # the team injuries list endpoint
+                return responses["LIST"]
+            return responses[url]
+
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = fake_get
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch('nfl_mcp.nfl_tools.create_http_client', return_value=mock_client):
+            result = await get_team_injuries("SF")
+
+        assert result["success"] is True
+        assert result["count"] == 1
+        inj = result["injuries"][0]
+        assert inj["player_name"] == "De'Zhaun Stribling"
+        assert inj["position"] == "WR"
+        assert inj["status"] == "Questionable"
+        assert inj["type"] == "Hamstring"
+        assert inj["return_date"] == "2026-08-13"
+        assert inj["severity"] == "Medium"
+
 
 class TestGetTeamPlayerStats:
     """Test get_team_player_stats function."""


### PR DESCRIPTION
Data-quality fixes for ESPN-backed team tools, surfaced while assessing the 49ers.

## 1. `get_team_injuries` returned empty rows
ESPN's `teams/{id}/injuries` returns bare `{"$ref": …}` links (→ injury object → nested athlete `$ref`). The tool treated each item as complete, so every field was empty. **Fix:** follow both hops concurrently (bounded to 10 in-flight) → `player_name`, `position`, `status`, `type` (body part), `description`, **`return_date`**, `severity`. Inline responses stay supported; `"Injured Reserve"` → `High`.

## 2. `get_coaching_staff` — head coach + coordinators
The ESPN coach object has no `displayName`/`position`, so the HC came back null. **Fix:** build the name from `firstName`/`lastName` and promote the coach ESPN returns (HC-only) to `head_coach`.

ESPN exposes **only** the head coach (confirmed across core / roster / site endpoints), so `offensive_coordinator`/`defensive_coordinator` are now enriched **best-effort from the Wikipedia season-page infobox** (`off_coach`/`def_coach`), with a `coordinator_source` field and an honest `note` about partial coverage. Optional `season` arg (defaults to current NFL season).

```
SF -> HC Kyle Shanahan (ESPN) | OC Klay Kubiak | DC Raheem Morris  (wikipedia)
KC -> HC Andy Reid (ESPN)     | OC/DC null (infobox had none)      -> honest note
```

## 3. `get_all_coaching_staffs` returned 0/32 head coaches
The coaches URL was `f"{team_url}/coaches"` where `team_url` already had a `?lang=…` query string → broken URL (`…?lang=…/coaches`) → every team `head_coach: null, coach_count: 0`. **Fix:** build from the numeric team id + resolve HC name from first/last. Now **31/32** live (one transient ESPN 503).

## Tests
- New hermetic tests: injury ref-dereferencing, HC resolution without `position`, and Wikipedia coordinator enrichment (+ missing-page path). Existing tests preserved (inline-response back-compat).
- Full suite: **915 passed, 2 skipped**. Ruff clean.

## Notes
- Coordinators via Wikipedia are **best-effort** — coverage is partial (some season pages only list the HC); the tool returns `null` + a note when unavailable.
- New external call: Wikipedia MediaWiki API (only in `get_coaching_staff`), best-effort and never fatal.