### PR TITLE
chore(release): 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-08-07
+
 ### Fixed
 - **`get_team_injuries` now returns real injury data (names, status, body part,
   return date).** ESPN's Core API returns the team injury list as bare

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfl_mcp"
-version = "0.7.0"
+version = "0.7.1"
 description = "NFL MCP Server - Fantasy Football Analysis via Model Context Protocol"
 authors = [{name = "gtonic", email = "tom.geiger@alp54.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
Patch release **0.7.1** (from current `main`). Bumps `pyproject.toml` and rolls the `CHANGELOG.md` `[Unreleased]` section into `## [0.7.1] - 2026-08-07`.

## Included (all from #140)
- **`get_team_injuries`** — dereferences ESPN Core-API `$ref` links (injury + athlete) → real `player_name`, `position`, `status`, body part, `return_date`, `severity` (was all empty).
- **`get_coaching_staff`** — resolves the head coach (name from first/last, HC promotion) and enriches `offensive_coordinator`/`defensive_coordinator` best-effort from the Wikipedia season-page infobox (`coordinator_source` + honest `note`; optional `season` arg).
- **`get_all_coaching_staffs`** — fixes the broken coaches URL (query string + `/coaches`) → head coaches now populate (was 0/32).

## Notes
- Diff is release-only: `pyproject.toml` version + `CHANGELOG.md` heading.
- Merging + tagging `v0.7.1` triggers the CI **Build & publish image** job → `ghcr.io/gtonic/nfl_mcp:0.7.1`.