### PR TITLE
fix(data): normalize scoring; flag preseason defense fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Scoring format is now normalized — `half_ppr` no longer silently means full
+  PPR.** `scoring_to_ppr` only recognized `half-ppr` (hyphen); Sleeper's own
+  `half_ppr` (underscore) and other spellings fell through to full PPR (1.0),
+  so a half-PPR league silently got full-PPR values in `get_draft_board`,
+  `get_player_value(s)`, `simulate_draft`, `recommend_draft_pick`, etc. It now
+  normalizes separators/case and accepts `half_ppr`/`halfppr`/`HALF PPR`/`std`/
+  `none`/raw numbers.
+- **`get_defense_rankings` no longer emits a fake ranking in the preseason.** The
+  neutral fallback (used when nflverse data isn't published yet) ranked teams
+  `1..32` in **alphabetical** order and the tool returned it with no fallback
+  flag — so matchup grades looked real but were alphabetical. The fallback is now
+  genuinely neutral (all teams rank 16) and the response carries `is_fallback`
+  plus a ⚠️ low-confidence message, mirroring `get_strength_of_schedule`.
+
+### Added
+- **`get_weather_forecast` now reports `forecast_unavailable`.** Games beyond
+  Open-Meteo's ~16-day horizon were already flagged per-game as
+  `impact.severity="unknown"`; the response now also carries a top-level count
+  (and a message note) so callers planning ahead aren't misled by empty weather
+  fields reading as "calm".
+
 ## [0.7.1] - 2026-08-07
 
 ### Fixed

--- a/nfl_mcp/matchup_tools.py
+++ b/nfl_mcp/matchup_tools.py
@@ -289,26 +289,26 @@ class DefenseRankingsAnalyzer:
         return name[:3].upper()
 
     def _get_fallback_rankings(self, position: str) -> list[dict]:
-        """
-        Return fallback rankings when API fails.
+        """Neutral fallback rankings when real data is unavailable (e.g. preseason).
 
-        Based on typical NFL defense patterns.
+        Every team is marked *neutral* (same middle rank/tier) rather than ranked
+        1..32 in alphabetical order — otherwise callers would mistake an arbitrary
+        alphabetical ordering for a real ranking. ``is_fallback`` flags each entry.
         """
-        # Generic fallback - all teams at neutral rating
         teams = list(ESPN_TEAM_MAP.values())
-        rankings = []
-
-        for rank, team in enumerate(sorted(teams), 1):
-            rankings.append({
+        neutral_rank = 16
+        tier = _get_matchup_tier(neutral_rank)
+        return [
+            {
                 "team": team,
-                "rank": rank,
-                "points_allowed_avg": 15.0,  # Average fantasy points
-                "matchup_tier": _get_matchup_tier(rank),
-                "tier_indicator": _get_tier_color(_get_matchup_tier(rank)),
-                "is_fallback": True
-            })
-
-        return rankings
+                "rank": neutral_rank,
+                "points_allowed_avg": 15.0,  # neutral placeholder
+                "matchup_tier": tier,
+                "tier_indicator": _get_tier_color(tier),
+                "is_fallback": True,
+            }
+            for team in sorted(teams)
+        ]
 
     def _save_rankings_to_db(self, rankings: dict, season: int) -> None:
         """Persist rankings to database for caching."""
@@ -547,11 +547,28 @@ async def get_defense_rankings(
         filtered = all_rankings
         positions = list(all_rankings.keys())
 
+    # Surface when the rankings are neutral placeholders (no live data yet),
+    # mirroring get_strength_of_schedule so callers don't treat them as real.
+    is_fallback = any(
+        entry.get("is_fallback")
+        for lst in filtered.values()
+        for entry in (lst or [])
+    )
+    if is_fallback:
+        message = (
+            f"⚠️ No live defense data for {season or datetime.now().year} "
+            "(preseason / not published yet) — rankings are neutral placeholders; "
+            "treat matchup grades as low-confidence."
+        )
+    else:
+        message = f"Defense rankings fetched for {len(positions)} positions"
+
     return create_success_response({
         "rankings": filtered,
         "positions": positions,
         "season": season or datetime.now().year,
         "total_teams": 32,
+        "is_fallback": is_fallback,
         "tiers_explained": {
             "elite": "Ranks 1-5: Tough matchup, consider benching",
             "tough": "Ranks 6-12: Above average defense",
@@ -560,7 +577,7 @@ async def get_defense_rankings(
             "smash": "Ranks 28-32: Excellent matchup, must start"
         },
         "usage_tip": "Use matchup tier + usage trends + injury status for start/sit decisions",
-        "message": f"Defense rankings fetched for {len(positions)} positions"
+        "message": message
     })
 
 

--- a/nfl_mcp/player_values.py
+++ b/nfl_mcp/player_values.py
@@ -46,19 +46,28 @@ _NAME_SUFFIXES = {"jr", "sr", "ii", "iii", "iv", "v"}
 
 
 def scoring_to_ppr(scoring: str | None) -> float:
-    """Map a scoring label to a PPR value (points per reception)."""
+    """Map a scoring label to a PPR value (points per reception).
+
+    Accepts common spellings and separators so callers can pass e.g. Sleeper's
+    own ``half_ppr`` (underscore) or ``half-ppr`` interchangeably. Recognized:
+    full PPR, half-PPR, and standard/non-PPR, plus a raw number (``"0.5"``).
+    Unrecognized non-numeric input falls back to full PPR (1.0).
+    """
     if scoring is None:
         return 1.0
-    s = str(scoring).strip().lower()
-    if s in ("ppr", "full", "full-ppr", "1", "1.0"):
+    raw = str(scoring).strip()
+    # Normalize separators (underscores/spaces -> hyphen) and case.
+    s = re.sub(r"[\s_]+", "-", raw.lower())
+    if s in ("ppr", "full", "full-ppr", "1-ppr", "1", "1.0"):
         return 1.0
-    if s in ("half", "half-ppr", "halfppr", "0.5", ".5"):
+    if s in ("half", "half-ppr", "halfppr", "half-point", "half-point-ppr",
+             "0.5", ".5", "0.5-ppr", "0.5ppr", "ppr-0.5"):
         return 0.5
-    if s in ("standard", "std", "non-ppr", "0", "0.0"):
+    if s in ("standard", "std", "non-ppr", "nonppr", "no-ppr", "none", "0", "0.0"):
         return 0.0
-    # Allow passing a raw number
+    # Allow passing a raw number like "0.75".
     try:
-        return float(s)
+        return float(raw)
     except ValueError:
         return 1.0
 

--- a/nfl_mcp/weather_tools.py
+++ b/nfl_mcp/weather_tools.py
@@ -273,13 +273,25 @@ async def get_weather_forecast(
 
     games.sort(key=lambda e: severity_order.get(e["impact"].get("severity"), 4))
 
+    # Surface how many games have no forecast yet (dates beyond Open-Meteo's
+    # ~16-day horizon show severity "unknown", not calm) so callers planning
+    # ahead aren't misled by empty weather fields.
+    unavailable = sum(1 for e in games if e["impact"].get("severity") == "unknown")
+    msg = (
+        f"Weather forecast for {len(games)} game(s) in week {week} of {season}, "
+        "worst-weather-first. Wind >=15 mph fades passing; kickers are hit hardest."
+    )
+    if unavailable:
+        msg += (
+            f" ⚠️ {unavailable} game(s) have no forecast yet (beyond the ~16-day "
+            "horizon or fetch failed) — reported as severity 'unknown', not calm."
+        )
+
     return create_success_response({
         "season": season,
         "week": week,
         "games": games,
         "count": len(games),
-        "message": (
-            f"Weather forecast for {len(games)} game(s) in week {week} of {season}, "
-            "worst-weather-first. Wind >=15 mph fades passing; kickers are hit hardest."
-        ),
+        "forecast_unavailable": unavailable,
+        "message": msg,
     })

--- a/tests/test_matchup_tools.py
+++ b/tests/test_matchup_tools.py
@@ -340,3 +340,36 @@ class TestNflverseRankings:
         an = DefenseRankingsAnalyzer(db=None)
         client = self._Client(self._Resp("", status=404))
         assert await an._fetch_nflverse_rankings(client, 2099) is None
+
+
+class TestDefenseFallback:
+    """Preseason fallback must be neutral and flagged, not fake-alphabetical."""
+
+    def test_fallback_rankings_are_neutral(self):
+        an = DefenseRankingsAnalyzer(db=None)
+        fb = an._get_fallback_rankings("QB")
+        assert len(fb) == 32
+        assert {r["rank"] for r in fb} == {16}          # no 1..32 alphabetical order
+        assert all(r["is_fallback"] for r in fb)
+
+    @pytest.mark.asyncio
+    async def test_get_defense_rankings_flags_fallback(self):
+        an = DefenseRankingsAnalyzer(db=None)
+        fallback = {p: an._get_fallback_rankings(p) for p in ("QB", "RB", "WR", "TE")}
+        fake = MagicMock()
+        fake.fetch_defense_rankings = AsyncMock(return_value=fallback)
+        with patch("nfl_mcp.matchup_tools.get_defense_analyzer", return_value=fake):
+            res = await matchup_tools.get_defense_rankings(season=2026)
+        assert res["success"] is True
+        assert res["is_fallback"] is True
+        assert "No live defense data" in res["message"]
+
+    @pytest.mark.asyncio
+    async def test_real_data_not_flagged(self):
+        real = {"QB": [{"team": "KC", "rank": 1, "is_fallback": False}]}
+        fake = MagicMock()
+        fake.fetch_defense_rankings = AsyncMock(return_value=real)
+        with patch("nfl_mcp.matchup_tools.get_defense_analyzer", return_value=fake):
+            res = await matchup_tools.get_defense_rankings(positions=["QB"], season=2025)
+        assert res["is_fallback"] is False
+        assert "Defense rankings fetched" in res["message"]

--- a/tests/test_player_values.py
+++ b/tests/test_player_values.py
@@ -136,3 +136,26 @@ class TestTools:
     async def test_get_player_value_requires_arg(self):
         res = await pv.get_player_value(db=_temp_db())
         assert res["success"] is False
+
+
+class TestScoringToPpr:
+    """scoring_to_ppr normalizes spellings/separators.
+
+    Regression for the silent bug where 'half_ppr' (Sleeper's own underscore
+    form) fell through to full PPR (1.0).
+    """
+
+    def test_normalizes_aliases(self):
+        assert pv.scoring_to_ppr("half_ppr") == 0.5   # underscore (Sleeper style)
+        assert pv.scoring_to_ppr("half-ppr") == 0.5
+        assert pv.scoring_to_ppr("HALF PPR") == 0.5
+        assert pv.scoring_to_ppr("halfppr") == 0.5
+        assert pv.scoring_to_ppr("0.5") == 0.5
+        assert pv.scoring_to_ppr("ppr") == 1.0
+        assert pv.scoring_to_ppr("full_ppr") == 1.0
+        assert pv.scoring_to_ppr("std") == 0.0
+        assert pv.scoring_to_ppr("standard") == 0.0
+        assert pv.scoring_to_ppr("none") == 0.0
+        assert pv.scoring_to_ppr("0.75") == 0.75
+        assert pv.scoring_to_ppr(None) == 1.0
+        assert pv.scoring_to_ppr("garbage") == 1.0    # unknown -> full PPR (documented)

--- a/tests/test_weather_tools.py
+++ b/tests/test_weather_tools.py
@@ -134,3 +134,24 @@ class TestGetWeatherForecast:
         result = await get_weather_forecast(season=2026, week=25)
         assert result["success"] is False
         assert "week must be" in result["error"]
+
+
+class TestForecastUnavailable:
+    """Games beyond the forecast horizon are flagged 'unknown' and counted."""
+
+    @pytest.mark.asyncio
+    async def test_forecast_unavailable_counted(self):
+        rows = [
+            {"team": "GB", "opponent": "CHI", "is_home": 1, "kickoff": "2026-09-13T17:00Z"},
+            {"team": "CHI", "opponent": "GB", "is_home": 0, "kickoff": "2026-09-13T17:00Z"},
+        ]
+        with patch("nfl_mcp.sleeper_tools._fetch_week_schedule",
+                   new=AsyncMock(return_value=rows)), \
+             patch("nfl_mcp.weather_tools._fetch_open_meteo",
+                   new=AsyncMock(return_value=None)):
+            res = await get_weather_forecast(season=2026, week=2)
+        assert res["success"] is True
+        assert res["count"] == 1                       # one home game (GB)
+        assert res["forecast_unavailable"] == 1        # out-of-range -> unknown
+        assert res["games"][0]["impact"]["severity"] == "unknown"
+        assert "no forecast" in res["message"]


### PR DESCRIPTION
Found by an exploratory test sweep across **draft-prep / live-draft / in-season** scenarios (preseason). Only the two genuine data-quality bugs below plus one minor enhancement — three other candidates turned out to be measurement artifacts of the test harness (documented working behavior) and were left untouched.

## 1. Scoring format not normalized → silent wrong values (fix)
`scoring_to_ppr` recognized only `half-ppr` (hyphen). Sleeper's own `half_ppr` (underscore) and other spellings fell through to **full PPR (1.0)**, so a half-PPR league silently got full-PPR values in `get_draft_board`, `get_player_value(s)`, `simulate_draft`, `recommend_draft_pick`.

Proof (before): `get_draft_board(scoring="half_ppr")` == `scoring="ppr"` (Bijan 10498), ≠ `half-ppr` (10492). After: `half_ppr == half-ppr` (10492). Now normalizes separators/case and accepts `half_ppr`/`halfppr`/`HALF PPR`/`std`/`none`/raw numbers.

## 2. `get_defense_rankings` emitted a fake ranking in preseason (fix)
The neutral fallback (nflverse data not published yet) ranked teams **1..32 in alphabetical order** (ARI=1 … WAS=32) with distinct matchup tiers, and the response had **no fallback flag** — so matchup grades looked real but were alphabetical.

Now the fallback is genuinely neutral (all teams rank 16) and the response carries `is_fallback: true` + a ⚠️ low-confidence message, mirroring `get_strength_of_schedule`. (This also improves downstream `get_matchup_difficulty`/`get_start_sit_recommendation`.)

## 3. `get_weather_forecast` — top-level unavailable count (enhancement)
Games beyond Open-Meteo's ~16-day horizon were already flagged per-game as `impact.severity="unknown"`; the response now also carries `forecast_unavailable` + a message note so callers planning ahead aren't misled by empty weather fields.

## Not changed (verified non-bugs)
- `get_player_value` nests data under `value` — **documented** and complete.
- `get_start_sit_recommendation` already returns `confidence`/`confidence_level`.
(Both earlier "findings" were my probe reading the wrong sub-fields.)

## Tests
- New: `scoring_to_ppr` aliases; defense fallback neutrality + `is_fallback` propagation (and real-data not flagged); weather `forecast_unavailable` count.
- Full suite: **920 passed, 2 skipped**. Ruff clean.