### PR TITLE
chore(release): 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-08-07
+
 ### Fixed
 - **Scoring format is now normalized — `half_ppr` no longer silently means full
   PPR.** `scoring_to_ppr` only recognized `half-ppr` (hyphen); Sleeper's own

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfl_mcp"
-version = "0.7.1"
+version = "0.7.2"
 description = "NFL MCP Server - Fantasy Football Analysis via Model Context Protocol"
 authors = [{name = "gtonic", email = "tom.geiger@alp54.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
Patch release **0.7.2** (from current `main`). Bumps `pyproject.toml` and rolls `[Unreleased]` into `## [0.7.2] - 2026-08-07`.

## Included (from #142)
- **Scoring normalization** — `half_ppr` (Sleeper's underscore form) no longer silently means full PPR; affects `get_draft_board`, `get_player_value(s)`, `simulate_draft`, `recommend_draft_pick`.
- **`get_defense_rankings` preseason fallback** — neutral (all rank 16) instead of a fake alphabetical 1..32, with an `is_fallback` flag + low-confidence message.
- **`get_weather_forecast`** — top-level `forecast_unavailable` count for games beyond the forecast horizon.

Diff is release-only. Tag `v0.7.2` will publish `ghcr.io/gtonic/nfl_mcp:0.7.2`.