### PR TITLE
fix(audit): repair 6 high-severity ESPN data bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+High-severity data-quality bugs found by the multi-agent tool audit (all
+reproduced against live ESPN data):
+- **`get_team_schedule` returned only the 3-game preseason slate.** The URL
+  omitted `seasontype`, so ESPN defaulted to preseason before the season starts.
+  Now requests `&seasontype=2` → the full 17-game regular season (and its bye gap),
+  which also fixes the downstream bye/SoS/matchup previews.
+- **`get_team_player_stats` always returned 0 players.** The URL carried a dead
+  `/types/{season_type}/` segment (404 for every season, masked as
+  `success=True, count=0`). Uses the season roster endpoint and dereferences the
+  athlete `$ref`s → real players (id/name/position/jersey).
+- **`get_nfl_standings` returned 4 placeholder rows with fabricated context.** The
+  Core API endpoint only exposes standings-TYPE group refs, not teams. Switched to
+  the site standings endpoint and parses `children[].standings.entries` → all 32
+  teams with real records; preseason (0-0) no longer fabricates a motivation level.
+- **`get_depth_chart` put player names in the `position` field.** ESPN renders
+  each unit as a *pair* of tables (position labels + player grid); the parser now
+  joins them, skips the `Starter` header, strips glued injury tags, and spaces the
+  team name (`San Francisco 49ers`).
+- **`get_high_confidence_injuries` was always empty.** Every ESPN injury got a
+  flat confidence of 60, unreachable by the default `min_confidence=70`. Confidence
+  is now graded by status certainty (Out/IR/Doubtful=90, Questionable=65, …), so
+  the threshold surfaces the genuinely high-confidence injuries.
+- **`get_league_leaders` was mis-wired.** The registry wrapper returned an
+  undocumented shape, rejected the documented `passing`/`rushing` labels, and
+  passed `limit` positionally into `season`. It now maps friendly labels to the
+  short tokens, calls the underlying by keyword, applies `limit`, and returns the
+  documented `{leaders, stat_type, count, season}` shape. (Note: ESPN's leaders
+  endpoint itself yields no data in the preseason.)
+
 ## [0.7.2] - 2026-08-07
 
 ### Fixed

--- a/nfl_mcp/injury_service.py
+++ b/nfl_mcp/injury_service.py
@@ -447,6 +447,21 @@ class InjuryAggregator:
             raw_status = status_data if isinstance(status_data, str) else status_data.get("description", "Unknown")
             normalized_status = self.normalize_status(raw_status)
 
+            # ESPN is a single source, but its status IS the confidence signal:
+            # a definitive "Out"/IR/Doubtful is far more certain than
+            # "Questionable" (which in turn beats a plain "Active" listing). A
+            # flat 60 made get_high_confidence_injuries(min_confidence=70) always
+            # empty, so grade confidence by status certainty instead.
+            _s = (normalized_status or "").lower()
+            if any(k in _s for k in ("out", "injured reserve", "reserve", "doubtful", "suspend")):
+                _confidence = 90
+            elif "questionable" in _s:
+                _confidence = 65
+            elif any(k in _s for k in ("probable", "active", "day", "limited")):
+                _confidence = 55
+            else:
+                _confidence = 50
+
             return InjuryReport(
                 player_id=str(player_id),
                 player_name=player_name,
@@ -457,7 +472,7 @@ class InjuryAggregator:
                 injury_description=data.get("shortComment") or data.get("longComment"),
                 game_status=None,
                 severity=self.get_severity(normalized_status),
-                confidence=60,  # Single source baseline
+                confidence=_confidence,
                 sources=["ESPN"],
                 date_reported=data.get("date"),
             )

--- a/nfl_mcp/nfl_tools.py
+++ b/nfl_mcp/nfl_tools.py
@@ -6,6 +6,7 @@ This module contains MCP tools for fetching NFL news, teams data, and depth char
 
 import asyncio
 import logging
+import re
 from typing import Any
 
 import httpx
@@ -256,41 +257,42 @@ async def get_depth_chart(team_id: str) -> dict:
         # Parse HTML content
         soup = BeautifulSoup(response.text, 'html.parser')
 
-        # Extract team name
+        # Extract team name (ESPN's <h1> glues city+nickname, e.g.
+        # "San Francisco49ers" -> add a space at the letter/digit boundary).
         team_name = None
         team_header = soup.find('h1')
         if team_header:
-            team_name = team_header.get_text(strip=True)
+            team_name = re.sub(r'(?<=[A-Za-z])(?=\d)', ' ', team_header.get_text(strip=True))
 
-        # Extract depth chart information
+        # Extract depth chart. ESPN renders each unit as a PAIR of tables: a
+        # 1-column table of position labels (QB/RB/…), immediately followed by a
+        # table whose first row is a header (Starter/2nd/3rd/4th) and whose
+        # remaining rows are the players, aligned row-for-row with the labels.
+        def _clean_name(name):
+            if not name or name == '-':
+                return None
+            # Strip an injury tag glued to the surname ("Jordan JamesQ" -> "…James").
+            return re.sub(r'(?<=[a-z])(IR|PUP|SUS|NFI|Q|O|D|P)$', '', name).strip() or None
+
         depth_chart = []
-
-        # Look for depth chart tables or sections
-        # ESPN depth chart structure may vary, so we'll look for common patterns
-        depth_sections = soup.find_all(['table', 'div'], class_=lambda x: x and 'depth' in x.lower() if x else False)
-
-        if not depth_sections:
-            # Try alternative selectors
-            depth_sections = soup.find_all('table')
-
-        for section in depth_sections:
-            # Extract position and players
-            rows = section.find_all('tr')
-            for row in rows:
-                cells = row.find_all(['td', 'th'])
-                if len(cells) >= 2:
-                    position = cells[0].get_text(strip=True)
-                    players = []
-                    for cell in cells[1:]:
-                        player_text = cell.get_text(strip=True)
-                        if player_text and player_text != position:
-                            players.append(player_text)
-
-                    if position and players:
-                        depth_chart.append({
-                            "position": position,
-                            "players": players
-                        })
+        tables = soup.find_all('table')
+        i = 0
+        while i < len(tables) - 1:
+            pos_rows = tables[i].find_all('tr')
+            player_rows = tables[i + 1].find_all('tr')
+            pos_is_single_col = bool(pos_rows) and len(pos_rows[0].find_all(['td', 'th'])) == 1
+            player_is_grid = bool(player_rows) and len(player_rows[0].find_all(['td', 'th'])) >= 2
+            if pos_is_single_col and player_is_grid:
+                pos_labels = [r.get_text(strip=True) for r in pos_rows]
+                # Row 0 of each is a header ('' and 'Starter …') -> skip it.
+                for pos_label, prow in zip(pos_labels[1:], player_rows[1:], strict=False):
+                    names = [_clean_name(c.get_text(strip=True)) for c in prow.find_all(['td', 'th'])]
+                    names = [n for n in names if n]
+                    if pos_label and names:
+                        depth_chart.append({"position": pos_label, "players": names})
+                i += 2
+            else:
+                i += 1
 
         return create_success_response({
             "team_id": team_id.upper(),
@@ -555,8 +557,10 @@ async def get_team_player_stats(team_id: str, season: int | None = 2026, season_
 
     headers = get_http_headers("nfl_teams")  # Reuse existing config
 
-    # ESPN Core API endpoint for team player statistics
-    url = f"https://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/{season}/types/{season_type}/teams/{team_id.upper()}/athletes?limit={limit}"
+    # ESPN Core API team roster for the season. The older
+    # /types/{season_type}/ variant now 404s; this endpoint returns athlete
+    # $ref links which we dereference below.
+    url = f"https://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/{season}/teams/{team_id.upper()}/athletes?limit={limit}"
 
     async with create_http_client() as client:
         try:
@@ -576,57 +580,50 @@ async def get_team_player_stats(team_id: str, season: int | None = 2026, season_
             else:
                 raise
 
-        # Parse JSON response
+        # Parse JSON response. `items` are athlete $ref links; dereference each.
         data = response.json()
+        athlete_items = data.get('items', [])
 
-        # Extract athletes from the response
-        athletes_data = data.get('items', [])
-
-        # Process athlete statistics
-        processed_stats = []
-        team_name = None
-
-        for athlete_item in athletes_data:
-            # Extract basic athlete info
-            player_stat = {
-                'player_id': athlete_item.get('id'),
-                'player_name': athlete_item.get('displayName', 'Unknown'),
-                'jersey': athlete_item.get('jersey'),
-                'position': None,
-                'age': athlete_item.get('age'),
-                'experience': athlete_item.get('experience', {}).get('years')
+        async def _resolve_athlete(item):
+            athlete = item
+            ref = item.get('$ref') if isinstance(item, dict) else None
+            if ref and not (isinstance(item, dict) and item.get('id')):
+                try:
+                    r = await client.get(ref, headers=headers)
+                    r.raise_for_status()
+                    athlete = r.json()
+                except Exception as e:
+                    logger.debug(f"[TeamPlayerStats] athlete ref fetch failed ({ref}): {e}")
+                    return None
+            position_ref = athlete.get('position') or {}
+            pos = position_ref.get('abbreviation', 'N/A') if isinstance(position_ref, dict) else 'N/A'
+            experience = athlete.get('experience')
+            return {
+                'player_id': athlete.get('id'),
+                'player_name': (athlete.get('displayName')
+                                or f"{athlete.get('firstName', '')} {athlete.get('lastName', '')}".strip()
+                                or 'Unknown'),
+                'jersey': athlete.get('jersey'),
+                'position': pos,
+                'age': athlete.get('age'),
+                'experience': experience.get('years') if isinstance(experience, dict) else None,
+                'active': athlete.get('active', True),
+                'fantasy_relevant': pos.upper() in ('QB', 'RB', 'WR', 'TE', 'K', 'DST'),
+                'stats_note': 'Detailed per-game statistics require additional API calls per player',
             }
 
-            # Get position info
-            position_ref = athlete_item.get('position', {})
-            if position_ref and isinstance(position_ref, dict):
-                player_stat['position'] = position_ref.get('abbreviation', 'N/A')
+        sem = asyncio.Semaphore(10)
 
-            # Get team info (should be consistent)
-            if not team_name:
-                team_ref = athlete_item.get('team', {})
-                if team_ref and isinstance(team_ref, dict):
-                    team_name = team_ref.get('displayName', 'Unknown Team')
+        async def _bounded(item):
+            async with sem:
+                return await _resolve_athlete(item)
 
-            # Try to get statistics if available (this may require additional API calls)
-            # For now, we'll include basic info and note that detailed stats may need separate calls
-            player_stat['stats_note'] = 'Detailed statistics require additional API calls per player'
-
-            # Check if player is active
-            player_stat['active'] = athlete_item.get('active', True)
-
-            # Fantasy relevance indicators
-            position = player_stat.get('position', '').upper()
-            if position in ['QB', 'RB', 'WR', 'TE', 'K', 'DST']:
-                player_stat['fantasy_relevant'] = True
-            else:
-                player_stat['fantasy_relevant'] = False
-
-            processed_stats.append(player_stat)
+        resolved = await asyncio.gather(*[_bounded(it) for it in athlete_items])
+        processed_stats = [p for p in resolved if p]
 
         return create_success_response({
             "team_id": team_id.upper(),
-            "team_name": team_name,
+            "team_name": None,
             "season": season,
             "season_type": season_type,
             "player_stats": processed_stats,
@@ -670,10 +667,10 @@ async def get_nfl_standings(season: int | None = 2026, season_type: int | None =
     # ESPN Core API endpoint for NFL standings
     if group is not None and group in [1, 2]:
         # Get specific conference standings
-        url = f"https://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/{season}/types/{season_type}/groups/{group}/standings"
+        url = f"https://site.api.espn.com/apis/v2/sports/football/nfl/standings?season={season}"
     else:
         # Get all standings
-        url = f"https://sports.core.api.espn.com/v2/sports/football/leagues/nfl/seasons/{season}/types/{season_type}/standings"
+        url = f"https://site.api.espn.com/apis/v2/sports/football/nfl/standings?season={season}"
 
     async with create_http_client() as client:
         response = await client.get(url, headers=headers)
@@ -682,48 +679,55 @@ async def get_nfl_standings(season: int | None = 2026, season_type: int | None =
         # Parse JSON response
         data = response.json()
 
-        # Extract standings from the response
-        standings_items = data.get('children', []) or data.get('items', [])
+        # The site standings endpoint returns children=conferences, each with
+        # standings.entries = real team rows (the Core API only exposed
+        # standings-TYPE group refs, which produced empty placeholder rows).
+        children = data.get('children') or []
+        if group in (1, 2):
+            want = 'afc' if group == 1 else 'nfc'
+            children = [
+                c for c in children
+                if want in (c.get('abbreviation') or c.get('name') or '').lower()
+            ]
+
+        entries = []
+        for child in children:
+            std = child.get('standings') or {}
+            entries.extend(std.get('entries') or [])
 
         processed_standings = []
+        for entry in entries:
+            team_ref = entry.get('team') or {}
+            team_info = {
+                'team_id': team_ref.get('id'),
+                'team_name': team_ref.get('displayName', 'Unknown'),
+                'abbreviation': team_ref.get('abbreviation', 'UNK'),
+            }
 
-        for standing_item in standings_items:
-            # Try to get team info from the standing entry
-            team_info = {}
-
-            # Extract team reference
-            team_ref = standing_item.get('team', {})
-            if team_ref and isinstance(team_ref, dict):
-                team_info['team_id'] = team_ref.get('id')
-                team_info['team_name'] = team_ref.get('displayName', 'Unknown')
-                team_info['abbreviation'] = team_ref.get('abbreviation', 'UNK')
-
-            # Extract standings statistics
-            stats = standing_item.get('stats', [])
-            for stat in stats:
-                stat_name = stat.get('name', '').lower()
+            for stat in (entry.get('stats') or []):
+                stat_name = (stat.get('name') or '').lower()
                 stat_value = stat.get('value')
-
-                if 'wins' in stat_name or stat_name == 'wins':
+                if stat_name == 'wins':
                     team_info['wins'] = stat_value
-                elif 'losses' in stat_name or stat_name == 'losses':
+                elif stat_name == 'losses':
                     team_info['losses'] = stat_value
-                elif 'ties' in stat_name or stat_name == 'ties':
+                elif stat_name == 'ties':
                     team_info['ties'] = stat_value
-                elif 'winpercent' in stat_name or 'win_percent' in stat_name:
+                elif stat_name == 'winpercent':
                     team_info['win_percentage'] = stat_value
-                elif 'playoffrank' in stat_name or 'playoff' in stat_name:
-                    team_info['playoff_rank'] = stat_value
-                elif 'divisionrank' in stat_name or 'division' in stat_name:
-                    team_info['division_rank'] = stat_value
+                elif stat_name == 'playoffseed':
+                    team_info['playoff_seed'] = stat_value
+                elif stat_name == 'divisionrecord':
+                    team_info['division_record'] = stat.get('displayValue')
 
-            # Calculate fantasy implications
-            wins = team_info.get('wins', 0)
-            losses = team_info.get('losses', 0)
+            # Fantasy implications (only meaningful once games have been played).
+            wins = team_info.get('wins') or 0
+            losses = team_info.get('losses') or 0
             total_games = wins + losses
-
-            # Determine team motivation level for fantasy purposes
-            if wins >= 12 or (total_games >= 14 and wins / total_games > 0.8):
+            if total_games == 0:
+                team_info['fantasy_context'] = 'Season not started — no games played yet'
+                team_info['motivation_level'] = 'Unknown (preseason)'
+            elif wins >= 12 or (total_games >= 14 and wins / total_games > 0.8):
                 team_info['fantasy_context'] = 'May rest starters in late season'
                 team_info['motivation_level'] = 'Low (Playoff lock)'
             elif wins <= 4 or (total_games >= 10 and wins / total_games < 0.3):
@@ -837,7 +841,9 @@ async def get_team_schedule(team_id: str, season: int | None = 2026) -> dict:
     headers = get_http_headers("nfl_teams")  # Reuse existing config
 
     # ESPN Site API endpoint for team schedule
-    url = f"https://site.api.espn.com/apis/site/v2/sports/football/nfl/teams/{team_id_upper}/schedule?season={season}"
+    # seasontype=2 => regular season (ESPN otherwise defaults to preseason when
+    # the regular season hasn't started, returning only the 3-game preseason slate).
+    url = f"https://site.api.espn.com/apis/site/v2/sports/football/nfl/teams/{team_id_upper}/schedule?season={season}&seasontype=2"
 
     async with create_http_client() as client:
         try:

--- a/nfl_mcp/tool_registry.py
+++ b/nfl_mcp/tool_registry.py
@@ -2378,14 +2378,38 @@ if FEATURE_LEAGUE_LEADERS:
         """Get NFL league leaders by stat type (feature-flagged).
 
         Parameters:
-            stat_type (str, default "passing"): Type of stat to get leaders for.
+            stat_type (str, default "passing"): passing/rushing/receiving/tackles/sacks.
             limit (int, default 25, range 1-100): Max leaders to return.
-        Returns: {leaders: [...], stat_type, count, success, error?}
+        Returns: {leaders: [...], stat_type, count, season, success, error?}
         Example: get_league_leaders(stat_type="rushing", limit=10)
         """
+        # Map friendly labels to the underlying short category tokens.
+        alias = {
+            "passing": "pass", "pass": "pass", "passingyards": "pass",
+            "rushing": "rush", "rush": "rush", "rushingyards": "rush",
+            "receiving": "receiving", "rec": "receiving", "receivingyards": "receiving",
+            "tackles": "tackles", "tackle": "tackles",
+            "sacks": "sacks", "sack": "sacks",
+        }
         try:
             stat_type = validate_string_input(stat_type, 'stat_type', max_length=20, required=True)
             limit = validate_limit(limit, 1, 100, 25)
-            return await nfl_tools.get_league_leaders(stat_type, limit)
         except ValueError as e:
             return {"leaders": [], "stat_type": stat_type, "count": 0, "success": False, "error": f"Invalid input: {e!s}"}
+
+        category = alias.get(stat_type.strip().lower().replace("_", ""), stat_type.strip().lower())
+        # Call by keyword (the underlying signature is get_league_leaders(category,
+        # season, season_type, week) — passing limit positionally landed in season).
+        res = await nfl_tools.get_league_leaders(category=category)
+        if not res.get("success"):
+            return {"leaders": [], "stat_type": stat_type, "count": 0,
+                    "success": False, "error": res.get("error"), "error_type": res.get("error_type")}
+        players = (res.get("players") or [])[:limit]
+        return {
+            "leaders": players,
+            "stat_type": res.get("category", category),
+            "count": len(players),
+            "season": res.get("season"),
+            "success": True,
+            "error": None,
+        }

--- a/tests/test_new_apis.py
+++ b/tests/test_new_apis.py
@@ -162,30 +162,36 @@ class TestNFLStandings:
         mock_response_data = {
             "children": [
                 {
-                    "team": {
-                        "id": "12",
-                        "displayName": "Kansas City Chiefs",
-                        "abbreviation": "KC"
-                    },
-                    "stats": [
-                        {"name": "wins", "value": 15},
-                        {"name": "losses", "value": 2},
-                        {"name": "ties", "value": 0},
-                        {"name": "winPercent", "value": 0.882}
-                    ]
-                },
-                {
-                    "team": {
-                        "id": "16",
-                        "displayName": "New York Giants",
-                        "abbreviation": "NYG"
-                    },
-                    "stats": [
-                        {"name": "wins", "value": 3},
-                        {"name": "losses", "value": 14},
-                        {"name": "ties", "value": 0},
-                        {"name": "winPercent", "value": 0.176}
-                    ]
+                    "standings": {
+                        "entries": [
+                            {
+                                "team": {
+                                    "id": "12",
+                                    "displayName": "Kansas City Chiefs",
+                                    "abbreviation": "KC"
+                                },
+                                "stats": [
+                                    {"name": "wins", "value": 15},
+                                    {"name": "losses", "value": 2},
+                                    {"name": "ties", "value": 0},
+                                    {"name": "winPercent", "value": 0.882}
+                                ]
+                            },
+                            {
+                                "team": {
+                                    "id": "16",
+                                    "displayName": "New York Giants",
+                                    "abbreviation": "NYG"
+                                },
+                                "stats": [
+                                    {"name": "wins", "value": 3},
+                                    {"name": "losses", "value": 14},
+                                    {"name": "ties", "value": 0},
+                                    {"name": "winPercent", "value": 0.176}
+                                ]
+                            }
+                        ]
+                    }
                 }
             ]
         }

--- a/tests/test_nfl_tools.py
+++ b/tests/test_nfl_tools.py
@@ -352,15 +352,21 @@ class TestGetNflStandings:
         mock_response.json.return_value = {
             "children": [
                 {
-                    "team": {
-                        "id": "1",
-                        "displayName": "Kansas City Chiefs",
-                        "abbreviation": "KC"
-                    },
-                    "stats": [
-                        {"name": "wins", "value": 14},
-                        {"name": "losses", "value": 3}
-                    ]
+                    "standings": {
+                        "entries": [
+                            {
+                                "team": {
+                                    "id": "1",
+                                    "displayName": "Kansas City Chiefs",
+                                    "abbreviation": "KC"
+                                },
+                                "stats": [
+                                    {"name": "wins", "value": 14},
+                                    {"name": "losses", "value": 3}
+                                ]
+                            }
+                        ]
+                    }
                 }
             ]
         }
@@ -528,3 +534,58 @@ class TestGetCurrentSeasonAndWeek:
             # Should return current year and week 0
             assert season is not None
             assert week == 0
+
+
+class TestAuditHighFixes:
+    """Regression tests for the audit HIGH-severity fixes."""
+
+    @pytest.mark.asyncio
+    async def test_depth_chart_pairs_position_and_player_tables(self):
+        html = (
+            "<html><body><h1>San Francisco49ers</h1>"
+            "<table><tr><td></td></tr><tr><td>QB</td></tr><tr><td>RB</td></tr></table>"
+            "<table>"
+            "<tr><th>Starter</th><th>2nd</th></tr>"
+            "<tr><td>Brock Purdy</td><td>Mac Jones</td></tr>"
+            "<tr><td>Christian McCaffrey</td><td>Jordan JamesQ</td></tr>"
+            "</table></body></html>"
+        )
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = html
+        mock_response.raise_for_status = MagicMock()
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch('nfl_mcp.nfl_tools.create_http_client', return_value=mock_client):
+            result = await get_depth_chart("SF")
+
+        assert result["success"] is True
+        assert result["team_name"] == "San Francisco 49ers"     # digit boundary spaced
+        by_pos = {d["position"]: d["players"] for d in result["depth_chart"]}
+        assert by_pos["QB"][0] == "Brock Purdy"                  # position label, not a name
+        assert by_pos["RB"][0] == "Christian McCaffrey"
+        assert "Jordan James" in by_pos["RB"]                    # trailing injury tag stripped
+
+    @pytest.mark.asyncio
+    async def test_league_leaders_wrapper_maps_and_reshapes(self):
+        from nfl_mcp import tool_registry
+        fn = {f.__name__: f for f in tool_registry.get_all_tools()}["get_league_leaders"]
+
+        captured = {}
+
+        async def fake(category=None, **kw):
+            captured["category"] = category
+            return {"success": True, "category": category, "season": 2024,
+                    "players": [{"rank": i, "athlete_name": f"P{i}"} for i in range(1, 11)]}
+
+        with patch("nfl_mcp.nfl_tools.get_league_leaders", fake):
+            res = await fn(stat_type="passing", limit=3)
+
+        assert captured["category"] == "pass"          # friendly label -> short token
+        assert res["success"] is True
+        assert {"leaders", "stat_type", "count"}.issubset(res.keys())   # documented shape
+        assert res["stat_type"] == "pass"
+        assert res["count"] == 3                        # limit applied (not shoved into season)


### PR DESCRIPTION
Fixes all **HIGH**-severity findings from the multi-agent tool audit. Every fix was reproduced against **live ESPN data** and re-verified after the change.

| Tool | Before | After |
|---|---|---|
| `get_team_schedule` | 3 preseason games | **17** regular-season games (`&seasontype=2`) |
| `get_team_player_stats` | `count=0` (dead `/types/` URL, 404 masked) | 50 real players (roster endpoint + `$ref` deref) |
| `get_nfl_standings` | 4 placeholder rows, fabricated context | **32** teams w/ real records (site endpoint → `children[].standings.entries`) |
| `get_depth_chart` | `position` held player names, QB/RB/WR missing | paired position/player tables joined; team name spaced |
| `get_high_confidence_injuries` | always empty (flat conf 60 vs default 70) | status-graded confidence (Out/IR=90 …) → real hits |
| `get_league_leaders` | wrong shape, rejected `passing`, `limit`→`season` | documented shape, label mapping, keyword call |

## Notes
- `get_nfl_standings` no longer fabricates a "motivation level" for 0-0 preseason teams.
- `get_league_leaders`: the wrapper wiring is fixed and returns the documented shape; ESPN's leaders endpoint itself has no data during the preseason (a deeper, separate empty-extraction issue in the underlying parser is noted for follow-up, beyond the audited wrapper bug).

## Tests
- Updated the 2 `get_nfl_standings` tests to the new `children[].standings.entries` structure.
- New regression tests: depth-chart paired-table parser; league-leaders wrapper mapping/reshape.
- Full suite: **922 passed, 2 skipped**. Ruff clean.

MEDIUM-severity findings follow in a second PR.