### PR TITLE
fix(audit): repair medium-severity data bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,28 @@ reproduced against live ESPN data):
   documented `{leaders, stat_type, count, season}` shape. (Note: ESPN's leaders
   endpoint itself yields no data in the preseason.)
 
+Medium-severity fixes from the same audit:
+- **`get_defense_rankings` (and the SoS/streaming/matchup tools it feeds) used a
+  renamed nflverse asset URL** (`player_stats_*` → 404), so they collapsed to
+  neutral placeholders even when real data existed. Updated to
+  `stats_player/stats_player_week_{season}.csv` → real defense data again (e.g.
+  2025 toughest QB defenses MIN/LAC/HOU).
+- **`get_rosters` fabricated phantom "healthy" players** for Sleeper's empty-slot
+  sentinel id `"0"` (9 per roster). The sentinel is now filtered before enrichment.
+- **`project_player` over-credited confidence and hid the Vegas fallback.** It
+  always passed an all-`None` usage dict (truthy → +15 confidence), reporting
+  85/high vs `project_players`' 70/medium for identical input; confidence now
+  requires a real usage signal. It also now surfaces `vegas_active` so a neutral
+  Vegas placeholder isn't mistaken for a live implied total.
+- **`get_playoff_preparation_plan` hard-coded a 4-week playoff** (`championship_week
+  = start+3`); corrected to the standard 3-week span (`start+2`).
+- **`get_injury_report` / `get_gameday_inactives` leaked the raw status enum**
+  (`INJURY_STATUS_ACTIVE`) as `injury_type`; now uses the body part / readable
+  description.
+- **`get_stack_opportunities` gave no fallback disclaimer** when `ODDS_API_KEY`
+  was unset (unlike `get_vegas_lines`); it now says so instead of reporting a bare
+  "no high-total games".
+
 ## [0.7.2] - 2026-08-07
 
 ### Fixed

--- a/nfl_mcp/injury_service.py
+++ b/nfl_mcp/injury_service.py
@@ -468,7 +468,10 @@ class InjuryAggregator:
                 team_id="",  # Will be set by caller
                 position=None,  # Not available in injury endpoint
                 injury_status=normalized_status,
-                injury_type=type_data.get("name") if isinstance(type_data, dict) else None,
+                # Prefer the body part; fall back to the human-readable status
+                # description ("active") — never the raw enum ("INJURY_STATUS_ACTIVE").
+                injury_type=((data.get("details") or {}).get("type")
+                             or (type_data.get("description") if isinstance(type_data, dict) else None)),
                 injury_description=data.get("shortComment") or data.get("longComment"),
                 game_status=None,
                 severity=self.get_severity(normalized_status),

--- a/nfl_mcp/matchup_tools.py
+++ b/nfl_mcp/matchup_tools.py
@@ -18,7 +18,7 @@ from .config import LONG_TIMEOUT, create_http_client
 # free CSV per season — the reliable source for defense-vs-position.
 NFLVERSE_PLAYER_STATS_URL = (
     "https://github.com/nflverse/nflverse-data/releases/download/"
-    "player_stats/player_stats_{season}.csv"
+    "stats_player/stats_player_week_{season}.csv"
 )
 # nflverse abbreviations -> the abbreviations used across this codebase.
 _NFLVERSE_TEAM_FIX = {"LA": "LAR", "WAS": "WSH", "JAC": "JAX", "OAK": "LV", "SD": "LAC", "STL": "LAR"}

--- a/nfl_mcp/projections.py
+++ b/nfl_mcp/projections.py
@@ -199,7 +199,15 @@ class ProjectionEngine:
             conf += 20
         if not env_is_fallback:
             conf += 15
-        if usage or base_source == "opportunity":
+        # Only credit real usage signal — project_player always passes a
+        # {snap_percentage: None, usage_trend: None} dict (truthy), which used to
+        # inflate confidence to 85/high with no actual usage data.
+        has_real_usage = (
+            base_source == "opportunity"
+            or usage.get("snap_percentage") is not None
+            or usage.get("usage_trend") is not None
+        )
+        if has_real_usage:
             conf += 15
         conf = min(conf, 100)
         conf_level = "high" if conf >= 80 else "medium" if conf >= 60 else "low"
@@ -216,6 +224,7 @@ class ProjectionEngine:
             "confidence_level": conf_level,
             "matchup_tier": matchup_tier,
             "implied_total": implied_total,
+            "vegas_active": not env_is_fallback,
             "breakdown": {
                 "base_ppg": base,
                 "base_source": base_source,

--- a/nfl_mcp/sleeper_strategy.py
+++ b/nfl_mcp/sleeper_strategy.py
@@ -537,8 +537,8 @@ async def get_playoff_preparation_plan(league_id: str, current_week: int) -> dic
             "current_week": current_week,
             "playoff_start": playoff_start,
             "weeks_to_playoffs": max(0, playoff_start - current_week),
-            "playoff_duration": 4,  # Typical playoff duration
-            "championship_week": playoff_start + 3
+            "playoff_duration": 3,  # standard fantasy playoff span (e.g. weeks 15-17)
+            "championship_week": playoff_start + 2
         },
         "preparation_phases": {},
         "strategic_priorities": [],

--- a/nfl_mcp/sleeper_tools.py
+++ b/nfl_mcp/sleeper_tools.py
@@ -308,10 +308,14 @@ async def get_rosters(league_id: str) -> dict:
                         # Because we need async inside enrichment, gather sequentially
                         for roster in rosters_data:
                             if isinstance(roster, dict):
+                                # "0" is Sleeper's empty-slot sentinel — filter it
+                                # (and blanks) so we don't fabricate phantom players.
                                 if isinstance(roster.get("players"), list):
-                                    roster["players_enriched"] = await enrich_players(roster["players"])
+                                    roster["players_enriched"] = await enrich_players(
+                                        [p for p in roster["players"] if p and p != "0"])
                                 if isinstance(roster.get("starters"), list):
-                                    roster["starters_enriched"] = await enrich_players(roster["starters"])
+                                    roster["starters_enriched"] = await enrich_players(
+                                        [p for p in roster["starters"] if p and p != "0"])
                 except Exception as enrich_error:
                     logger.debug(f"Roster enrichment (extended) skipped: {enrich_error}")
 

--- a/nfl_mcp/vegas_tools.py
+++ b/nfl_mcp/vegas_tools.py
@@ -820,6 +820,11 @@ async def get_stack_opportunities(
 
         primary_teams = list({s["primary_stack_team"] for s in stacks[:3]})
         summary.append(f"📈 Target: {', '.join(primary_teams)} pass games")
+    elif not analyzer.api_key:
+        summary.append(
+            "⚠️ No Vegas lines available — set ODDS_API_KEY to enable live totals; "
+            "stack opportunities can't be computed."
+        )
     else:
         summary.append(f"⚠️ No games with O/U >= {min_total} found")
 


### PR DESCRIPTION
Second batch from the multi-agent audit — the tractable **MEDIUM** findings. All verified against live data.

| Tool | Fix |
|---|---|
| `get_defense_rankings` (+SoS/streaming/matchup) | nflverse URL renamed → real data restored (2025 `is_fallback=False`; toughest QB D: MIN/LAC/HOU) |
| `get_rosters` | filter Sleeper's `"0"` empty-slot sentinel → **0** phantom players (was 9/roster) |
| `project_player` | usage confidence only when real usage given (CMC 85/high → **70/medium**, matches `project_players`); adds `vegas_active` flag |
| `get_playoff_preparation_plan` | `championship_week = playoff_start+2` (3-week playoff), not a hard-coded +3 |
| `get_injury_report` / `get_gameday_inactives` | `injury_type` = body part / readable description, not `INJURY_STATUS_ACTIVE` |
| `get_stack_opportunities` | adds the no-`ODDS_API_KEY` fallback disclaimer |

Full suite: **922 passed, 2 skipped**. Ruff clean.

## Deferred to a follow-up (deeper, need more than a surgical fix)
These MEDIUM findings each need real logic derivation rather than a small change, so they're intentionally **not** in this PR:
- **`get_season_bye_week_coordination` / `get_strategic_matchup_preview`** — byes must be *derived from the week gap* in the (now-fixed) regular-season schedule, not matched against a "BYE WEEK" string that's never emitted.
- **`get_playoff_odds`** — needs a `games_remaining == 0` guard so it stops presenting a deterministic 100/0 split + hard-coded `mean_ppg=100` as real odds.
- **`get_playoff_preparation_plan` readiness_assessment** — should be derived from the actual roster/schedule, not from timeline arithmetic.
- **`recommend_faab_bid`** — should reframe the bid as a waiver *priority* in non-FAAB leagues.
- **`get_game_environment`** — the documented top-level `game` field is missing (KeyError on `result['game']`).

Low-severity consistency/schema findings (#19–#26 from the audit) also remain for later.