### PR TITLE
fix(audit): resolve the deeper medium-severity findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,26 @@ Medium-severity fixes from the same audit:
   was unset (unlike `get_vegas_lines`); it now says so instead of reporting a bare
   "no high-total games".
 
+The deeper medium-severity findings (logic derivation, not surgical fixes):
+- **Bye weeks are now derived from the schedule gap.** `get_team_schedule` returns
+  a `bye_week` (the one regular-season week 1-18 with no game — ESPN encodes a bye
+  as a *missing* week, not a game row). `get_season_bye_week_coordination` and
+  `get_strategic_matchup_preview` read it instead of matching a `"BYE WEEK"` string
+  that was never emitted, so the bye calendar is populated again.
+- **`get_playoff_odds` no longer invents odds with no schedule.** With
+  `games_remaining == 0` (preseason / schedule unavailable) it returned a
+  deterministic 100/0 split by roster id and a hard-coded `mean_ppg=100`; it now
+  returns `computable: false` with an explanation.
+- **`get_playoff_preparation_plan` stops fabricating a roster grade.** The
+  readiness score reflects only preparation *timing*, so `roster_depth` /
+  `schedule_strength` / `bye_week_planning` are now labelled "Not assessed" (with
+  pointers to the tools that do assess them) instead of grading an empty pre-draft
+  roster "Good".
+- **`recommend_faab_bid` reframes non-FAAB leagues.** In a waiver-priority league
+  the message now says to use a priority claim rather than "Bid ~75%".
+- **`get_game_environment` returns its documented `game` field** (was missing →
+  `KeyError` on `result['game']`).
+
 ## [0.7.2] - 2026-08-07
 
 ### Fixed

--- a/nfl_mcp/faab_tools.py
+++ b/nfl_mcp/faab_tools.py
@@ -215,7 +215,12 @@ async def recommend_faab_bid(
         "is_faab_league": is_faab,
         "total_budget": total_budget if is_faab else None,
         "remaining_budget": remaining_budget,
-        "message": (f"Bid ~{bid_pct}% "
-                    + (f"(${bid_absolute} of {total_budget}) " if bid_absolute is not None else "")
-                    + f"on {target.get('name')} [{tier}]"),
+        "message": (
+            (f"Bid ~{bid_pct}% "
+             + (f"(${bid_absolute} of {total_budget}) " if bid_absolute is not None else "")
+             + f"on {target.get('name')} [{tier}]")
+            if is_faab else
+            (f"Non-FAAB league — use a high waiver-priority claim on {target.get('name')} "
+             f"[{tier}] (value {int(target_value)}); the bid_pct below is only a priority heuristic.")
+        ),
     })

--- a/nfl_mcp/nfl_tools.py
+++ b/nfl_mcp/nfl_tools.py
@@ -952,17 +952,23 @@ async def get_team_schedule(team_id: str, season: int | None = 2026) -> dict:
                     elif game['week'] >= 15:
                         game['fantasy_implications'].append("Late season - potential rest concerns for playoff teams")
 
-                # Add bye week identification
-                if game['season_type'] == 'Bye Week':
-                    game['fantasy_implications'].append("BYE WEEK - No fantasy points available")
-
             processed_schedule.append(game)
+
+        # Derive the bye week: the single regular-season week (1-18) with no game.
+        # ESPN encodes a bye as a *missing* week rather than a game row, so it must
+        # be inferred from the gap (only when we have a near-complete schedule).
+        played_weeks = {g.get('week') for g in processed_schedule if isinstance(g.get('week'), int)}
+        bye_week = (
+            next((w for w in range(1, 19) if w not in played_weeks), None)
+            if len(played_weeks) >= 16 else None
+        )
 
         return create_success_response({
             "team_id": team_id_upper,
             "team_name": team_name,
             "season": season,
             "schedule": processed_schedule,
+            "bye_week": bye_week,
             "count": len(processed_schedule),
             "cache_source": "api"
         })

--- a/nfl_mcp/playoff_tools.py
+++ b/nfl_mcp/playoff_tools.py
@@ -181,6 +181,20 @@ async def get_playoff_odds(
     remaining_weeks = list(range(current_week, regular_weeks + 1))
     schedule = await _build_remaining_schedule(league_id, remaining_weeks) if remaining_weeks else []
 
+    # No remaining games (e.g. preseason / schedule not published) -> the sim
+    # would otherwise emit a deterministic 100/0 split by roster id. Flag it.
+    if not schedule:
+        return create_success_response({
+            "odds": [],
+            "playoff_teams": playoff_teams,
+            "regular_season_weeks": regular_weeks,
+            "current_week": current_week,
+            "games_remaining": 0,
+            "computable": False,
+            "message": ("Playoff odds can't be computed yet — no remaining scheduled "
+                        "games (preseason or schedule not available)."),
+        })
+
     rng = random.Random(seed)
     sim = _simulate(teams, schedule, playoff_teams, max(100, min(int(num_sims), 50000)), score_sd, rng)
 

--- a/nfl_mcp/sleeper_strategy.py
+++ b/nfl_mcp/sleeper_strategy.py
@@ -148,18 +148,15 @@ async def get_strategic_matchup_preview(league_id: str, current_week: int, weeks
             try:
                 team_schedule = await nfl_tools.get_team_schedule(team, 2026)
                 if team_schedule.get("success", False):
-                    schedule = team_schedule.get("schedule", [])
-                    for game in schedule:
-                        if (game.get("week") == target_week and
-                            "BYE WEEK" in game.get("fantasy_implications", [])):
-                            week_analysis["bye_week_teams"].append({
-                                "team": team,
-                                "impact": "High - Consider backup options or trades"
-                            })
-                            strategic_data["summary"]["critical_bye_weeks"].append({
-                                "week": target_week,
-                                "team": team
-                            })
+                    if team_schedule.get("bye_week") == target_week:
+                        week_analysis["bye_week_teams"].append({
+                            "team": team,
+                            "impact": "High - Consider backup options or trades"
+                        })
+                        strategic_data["summary"]["critical_bye_weeks"].append({
+                            "week": target_week,
+                            "team": team
+                        })
             except Exception:
                 # Skip team if schedule unavailable
                 continue
@@ -281,14 +278,9 @@ async def get_season_bye_week_coordination(league_id: str, season: int = 2026) -
         try:
             team_schedule = await nfl_tools.get_team_schedule(team, season)
             if team_schedule.get("success", False):
-                schedule = team_schedule.get("schedule", [])
-                for game in schedule:
-                    if "BYE WEEK" in game.get("fantasy_implications", []):
-                        week_num = game.get("week")
-                        if week_num:
-                            if week_num not in bye_weeks_by_week:
-                                bye_weeks_by_week[week_num] = []
-                            bye_weeks_by_week[week_num].append(team)
+                week_num = team_schedule.get("bye_week")
+                if week_num:
+                    bye_weeks_by_week.setdefault(week_num, []).append(team)
         except Exception:
             continue
 
@@ -668,19 +660,18 @@ async def get_playoff_preparation_plan(league_id: str, current_week: int) -> dic
 
     playoff_plan["readiness_assessment"]["overall_score"] = min(100, readiness_score)
 
-    # Set readiness levels based on score
-    if readiness_score >= 80:
-        playoff_plan["readiness_assessment"]["roster_depth"] = "Excellent"
-        playoff_plan["readiness_assessment"]["schedule_strength"] = "Strong"
-        playoff_plan["readiness_assessment"]["bye_week_planning"] = "Well Prepared"
-    elif readiness_score >= 60:
-        playoff_plan["readiness_assessment"]["roster_depth"] = "Good"
-        playoff_plan["readiness_assessment"]["schedule_strength"] = "Adequate"
-        playoff_plan["readiness_assessment"]["bye_week_planning"] = "Prepared"
-    else:
-        playoff_plan["readiness_assessment"]["roster_depth"] = "Needs Work"
-        playoff_plan["readiness_assessment"]["schedule_strength"] = "Challenging"
-        playoff_plan["readiness_assessment"]["bye_week_planning"] = "Behind Schedule"
+    # The score above reflects only *preparation timing* (weeks-to-playoffs +
+    # whether NFL schedule analysis ran) — it is NOT a measurement of the actual
+    # roster or schedule, so don't fabricate a roster_depth grade (an empty
+    # pre-draft roster used to be graded "Good"). Label honestly and point at the
+    # tools that do assess each dimension.
+    ra = playoff_plan["readiness_assessment"]
+    ra["score_basis"] = "preparation timing only (not roster/schedule quality)"
+    ra["prep_timing"] = ("Excellent" if readiness_score >= 80
+                         else "Good" if readiness_score >= 60 else "Needs Work")
+    ra["roster_depth"] = "Not assessed — draft/set your roster to evaluate"
+    ra["schedule_strength"] = "Not assessed — see get_playoff_sos / get_strength_of_schedule"
+    ra["bye_week_planning"] = "Not assessed — see get_season_bye_week_coordination"
 
     return create_success_response({
         "playoff_plan": playoff_plan,

--- a/nfl_mcp/vegas_tools.py
+++ b/nfl_mcp/vegas_tools.py
@@ -570,6 +570,7 @@ async def get_game_environment(
 
     result = {
         "team": team_norm,
+        "game": game,  # full game data with Vegas lines (documented top-level field)
         "opponent": game.get("away_team") if is_home else game.get("home_team"),
         "is_home": is_home,
         "spread": game.get("home_spread") if is_home else game.get("away_spread"),


### PR DESCRIPTION
The remaining MEDIUM findings from the audit — the ones that needed real logic derivation (deferred from #145). All verified against live data.

| Tool | Fix |
|---|---|
| `get_team_schedule` + bye tools | derive `bye_week` from the schedule gap (SF → **week 8**); `get_season_bye_week_coordination` calendar populated (was empty) |
| `get_playoff_odds` | `games_remaining == 0` → `computable: false` + message (was a deterministic 100/0 split by roster id) |
| `get_playoff_preparation_plan` | readiness labelled by prep *timing*; `roster_depth`/`schedule_strength`/`bye_week_planning` = "Not assessed" (was grading an empty roster "Good") |
| `recommend_faab_bid` | non-FAAB → waiver-priority message (not "Bid ~75%") |
| `get_game_environment` | returns the documented top-level `game` field (was a `KeyError`) |

Full suite: **922 passed, 2 skipped**. Ruff clean.

## Remaining
Only the **low-severity** audit findings (#19–#26: consistency/schema polish — `get_teams` logo, `get_cbs_expert_picks` parsing, `analyze_opponent`/`analyze_trade` edge labels, `get_player_values` `updated_at`, etc.) are left. Plus the separately-noted deeper `get_league_leaders` underlying leaders-endpoint extraction (returns empty even for completed seasons — beyond the audited wrapper bug).