### PR TITLE
fix(audit): resolve low-severity consistency/schema findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,23 @@ The deeper medium-severity findings (logic derivation, not surgical fixes):
 - **`get_game_environment` returns its documented `game` field** (was missing →
   `KeyError` on `result['game']`).
 
+Low-severity consistency/schema polish from the audit:
+- **`get_teams` now returns team logos.** ESPN exposes images under `logos` (a
+  list), not `logo`, so the field was empty for all 32 teams.
+- **`get_draft_board` / `recommend_draft_pick` / `simulate_draft` echo the
+  effective `ppr`.** The `format` block now includes the resolved `ppr` value, so
+  an unrecognized `scoring` label (which maps to full PPR) is transparent.
+- **`get_player_values` reports `updated_at` for fresh data** (fell back to the
+  DB snapshot time, which is null on a fresh fetch → now uses `fetched_at`).
+- **`analyze_roster_vegas` surfaces the Vegas fallback at the top level** (an
+  `is_fallback` flag + a message note) instead of only per-entry.
+- **`analyze_opponent` no longer rates an empty roster "100% vulnerable."** A
+  pre-draft/empty opponent roster returns `no_data: true` (`vulnerability_score:
+  null`) instead of fabricating "critical" weaknesses at every position.
+- **`analyze_trade` resolves off-roster players' real identity.** A traded player
+  not on the given roster is backfilled with the name/position from the value list
+  (was `"Unknown (4034)"` despite a resolved value) and flagged in `warnings`.
+
 ## [0.7.2] - 2026-08-07
 
 ### Fixed

--- a/nfl_mcp/draft_tools.py
+++ b/nfl_mcp/draft_tools.py
@@ -177,7 +177,8 @@ async def get_draft_board(
         "total": len(board),
         "tiers_by_position": tiers_by_position,
         "replacement_values": vbd["replacement"],
-        "format": {"scoring": scoring, "superflex": superflex, "num_teams": num_teams, "dynasty": dynasty},
+        "format": {"scoring": scoring, "ppr": scoring_to_ppr(scoring), "superflex": superflex,
+                   "num_teams": num_teams, "dynasty": dynasty},
         "source": data.get("source"),
         "stale": data.get("stale", False),
         "message": (
@@ -416,7 +417,8 @@ async def recommend_draft_pick(
             "starter_requirements": reqs,
         } if my_slot is not None else None,
         "picks_made": len(picks),
-        "format": {"scoring": scoring, "superflex": superflex, "num_teams": num_teams, "dynasty": dynasty},
+        "format": {"scoring": scoring, "ppr": scoring_to_ppr(scoring), "superflex": superflex,
+                   "num_teams": num_teams, "dynasty": dynasty},
         "source": data.get("source"),
         "stale": data.get("stale", False),
         "message": (
@@ -699,8 +701,8 @@ async def simulate_draft(
 
     result: dict[str, Any] = {
         "sample": sample,
-        "format": {"scoring": scoring, "superflex": superflex, "num_teams": num_teams,
-                   "dynasty": dynasty, "rounds": rounds},
+        "format": {"scoring": scoring, "ppr": scoring_to_ppr(scoring), "superflex": superflex,
+                   "num_teams": num_teams, "dynasty": dynasty, "rounds": rounds},
         "starter_requirements": reqs,
         "num_sims": n,
         "source": data.get("source"),

--- a/nfl_mcp/nfl_tools.py
+++ b/nfl_mcp/nfl_tools.py
@@ -150,7 +150,9 @@ async def get_teams() -> dict:
                 "location": team_info.get('location', ''),
                 "color": team_info.get('color', ''),
                 "alternateColor": team_info.get('alternateColor', ''),
-                "logo": team_info.get('logo', '')
+                # ESPN exposes team images under `logos` (a list), not `logo`.
+                "logo": ((team_info.get('logos') or [{}])[0].get('href')
+                         or team_info.get('logo') or '')
             }
             processed_teams.append(processed_team)
 

--- a/nfl_mcp/opponent_analysis_tools.py
+++ b/nfl_mcp/opponent_analysis_tools.py
@@ -297,6 +297,22 @@ class OpponentAnalyzer:
         all_players = opponent_roster.get("players_enriched", [])
         starters = opponent_roster.get("starters_enriched", [])
 
+        # An empty (undrafted / pre-draft) roster isn't "100% vulnerable" —
+        # every position would score 0 and invert to a max vulnerability. Flag
+        # it as no-data instead of fabricating "critical" weaknesses.
+        if not all_players and not starters:
+            return {
+                "vulnerability_score": None,
+                "vulnerability_level": "unknown",
+                "no_data": True,
+                "position_assessments": {},
+                "starter_weaknesses": [],
+                "exploitation_strategies": [],
+                "roster_id": opponent_roster.get("roster_id"),
+                "owner_id": opponent_roster.get("owner_id"),
+                "message": "Opponent roster is empty (not drafted yet) — nothing to analyze.",
+            }
+
         # Group players by position
         players_by_position = defaultdict(list)
         for player in all_players:

--- a/nfl_mcp/player_values.py
+++ b/nfl_mcp/player_values.py
@@ -302,7 +302,10 @@ async def get_player_values(
         },
         "source": data.get("source"),
         "stale": data.get("stale", False),
-        "updated_at": data.get("snapshot_updated_at"),
+        "updated_at": (
+            data.get("snapshot_updated_at")
+            or (data["fetched_at"].isoformat() if data.get("fetched_at") else None)
+        ),
         "message": (
             f"{len(values)} player values ({data.get('source')})"
             + (" ⚠️ STALE cached data" if data.get("stale") else "")

--- a/nfl_mcp/trade_analyzer_tools.py
+++ b/nfl_mcp/trade_analyzer_tools.py
@@ -375,6 +375,13 @@ async def analyze_trade(
                 value, value_source, market = analyzer._calculate_player_value(
                     player, service, values_index
                 )
+                # If the player wasn't on the roster we still resolved a market
+                # value — backfill the real name/position instead of "Unknown (id)".
+                if market and str(player.get("full_name", "")).startswith("Unknown"):
+                    player["full_name"] = market.get("name") or player["full_name"]
+                    player["position"] = market.get("position") or player.get("position") or ""
+                    player.setdefault("warnings", []).append(
+                        "Not on the given roster — identity resolved from the value list")
                 player["calculated_value"] = round(value, 1)
                 player["value_source"] = value_source
                 player["overall_rank"] = (market or {}).get("overall_rank")

--- a/nfl_mcp/vegas_tools.py
+++ b/nfl_mcp/vegas_tools.py
@@ -716,7 +716,12 @@ async def analyze_roster_vegas(
             worst_environments.append(f"{name} ({team_norm}) - O/U {game.get('total')}")
 
     # Generate summary
+    all_fallback = bool(analyses) and all(a.get("is_fallback") for a in analyses)
     summary_lines = []
+    if all_fallback:
+        summary_lines.append(
+            "⚠️ No live Vegas lines (set ODDS_API_KEY) — neutral placeholder values"
+        )
     if best_environments:
         summary_lines.append(f"🔥 BEST ENVIRONMENTS: {', '.join(best_environments[:3])}")
     if worst_environments:
@@ -727,8 +732,10 @@ async def analyze_roster_vegas(
         "best_environments": best_environments,
         "worst_environments": worst_environments,
         "summary": summary_lines,
+        "is_fallback": all_fallback,
         "total_analyzed": len(analyses),
-        "message": f"Analyzed Vegas lines for {len(analyses)} players"
+        "message": (f"Analyzed Vegas lines for {len(analyses)} players"
+                    + (" (⚠️ fallback/neutral — no ODDS_API_KEY)" if all_fallback else "")),
     })
 
 


### PR DESCRIPTION
Final batch from the audit — the **LOW**-severity consistency/schema findings. All verified live.

| Tool | Fix |
|---|---|
| `get_teams` | logos now populated (32/32) — read `logos[0].href`, not the dropped `logo` field |
| `get_draft_board` / `recommend_draft_pick` / `simulate_draft` | `format` echoes the effective `ppr` (unknown scoring → full-PPR is now transparent) |
| `get_player_values` | `updated_at` falls back to `fetched_at` (was null on fresh fetches) |
| `analyze_roster_vegas` | top-level `is_fallback` + message when all entries are neutral placeholders |
| `analyze_opponent` | empty/pre-draft roster → `no_data:true` / `vulnerability_score:null` (was "100% vulnerable") |
| `analyze_trade` | off-roster player backfilled with real name/position from the value list (was `"Unknown (4034)"`) + warning |

Full suite: **922 passed, 2 skipped**. Ruff clean.

## Left for a dedicated follow-up
- **`get_cbs_expert_picks`** — the scraped CBS HTML is parsed into concatenated/garbled text; fixing it is a scraping-parser rewrite against live HTML (LOW severity, highest effort).
- **`get_league_leaders` underlying leaders-endpoint extraction** — returns empty even for completed seasons (the audited *wrapper* bug is already fixed in #144; this is the deeper ESPN-structure parser).

This completes **all HIGH + MEDIUM + LOW audit findings** except those two noted items.