### PR TITLE
chore(release): 0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.5] - 2026-08-07
+
 ### Fixed
 High-severity data-quality bugs found by the multi-agent tool audit (all
 reproduced against live ESPN data):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfl_mcp"
-version = "0.7.2"
+version = "0.7.5"
 description = "NFL MCP Server - Fantasy Football Analysis via Model Context Protocol"
 authors = [{name = "gtonic", email = "tom.geiger@alp54.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
Release **0.7.5** — ships the full multi-agent tool-audit remediation (PRs #144/#145/#146/#147). Bumps `pyproject.toml` and rolls the `[Unreleased]` audit fixes into `## [0.7.5] - 2026-08-07`.

## Included (24 audit findings across 4 batches)
- **HIGH (6):** `get_team_schedule` (seasontype), `get_team_player_stats` (deref), `get_nfl_standings` (site endpoint), `get_depth_chart` (paired tables), `get_high_confidence_injuries` (status-graded confidence), `get_league_leaders` (wrapper).
- **MEDIUM (12):** nflverse URL (defense/SoS/streaming/matchup real data), roster `"0"` sentinel, `project_player` confidence + `vegas_active`, bye-week derivation, `get_playoff_odds` guard, playoff-prep readiness honesty, FAAB non-FAAB reframe, injury_type enum, stack/game-env flags.
- **LOW (6):** `get_teams` logos, scoring-echo `ppr`, `player_values.updated_at`, `analyze_roster_vegas` fallback flag, `analyze_opponent` empty-roster guard, `analyze_trade` off-roster name.

Full suite: **922 passed, 2 skipped**. Diff is release-only. Tag `v0.7.5` publishes `ghcr.io/gtonic/nfl_mcp:0.7.5`.

## Known follow-ups (documented, not in this release)
`get_cbs_expert_picks` scraping rewrite; the deeper `get_league_leaders` leaders-endpoint parser.