### PR TITLE
fix(audit): resolve the two deferred deep follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+The two deeper audit follow-ups (deferred from the 0.7.5 batches):
+- **`get_league_leaders` now returns actual leaders.** ESPN's `leaders` endpoint
+  returns a *flat* list of leader entries (each with an `athlete` `$ref`), but the
+  parser treated each entry as a *group* and expanded it to `[]` — so even
+  completed seasons came back empty. It now uses the entries directly (deref
+  athlete/team, ordered rank), e.g. 2024 passing → Burrow / Goff / Mayfield.
+- **`get_cbs_expert_picks` is parsed properly.** Rewrote the scraper against the
+  `TableExpertPicks` layout: clean expert names from the header row, per-game
+  `picks` keyed by expert, extracted `away_team`/`home_team`, and
+  whitespace-collapsed text — instead of concatenated blobs like
+  `"FINALNBCDAL7-9-120PHI…"` and duplicated experts.
+
 ## [0.7.5] - 2026-08-07
 
 ### Fixed

--- a/nfl_mcp/cbs_fantasy_tools.py
+++ b/nfl_mcp/cbs_fantasy_tools.py
@@ -310,70 +310,51 @@ async def get_cbs_expert_picks(week: int | None = None) -> dict:
         response = await client.get(url, headers=headers, follow_redirects=True)
         response.raise_for_status()
 
-        # Parse HTML content
+        # CBS renders one `TableExpertPicks` table: row 0 = expert names (header),
+        # row 1 = their records, rows 2+ = one game each (first cell = matchup,
+        # remaining cells = each expert's pick for that game).
         soup = BeautifulSoup(response.text, 'html.parser')
-
-        # Extract picks data
         processed_picks = []
+        experts: list[str] = []
 
-        # Look for picks table or containers
-        picks_table = soup.find('table', class_=re.compile(r'picks|games|matchup', re.I))
+        table = (soup.find('table', class_=re.compile(r'TableExpertPicks', re.I))
+                 or soup.find('table', class_=re.compile(r'picks', re.I)))
+        if table:
+            rows = table.find_all('tr')
+            header_cells = rows[0].find_all(['th', 'td']) if rows else []
+            # First column is the matchup column; the rest are the experts.
+            for c in header_cells[1:]:
+                name = c.get_text(' ', strip=True)
+                # Drop a trailing role/title glued onto the name.
+                name = re.sub(r'\s+(Senior|Writer|Analyst|NFL|Fantasy|Editor|Insider).*$', '', name).strip()
+                experts.append(name or c.get_text(' ', strip=True))
 
-        if picks_table:
-            # Find data rows
-            rows = picks_table.find_all('tr')
-
-            for row in rows[1:]:  # Skip header row
-                cells = row.find_all(['td', 'th'])
-                if len(cells) >= 3:
-                    pick = {}
-
-                    # Extract game/matchup info (usually first cell)
-                    matchup_cell = cells[0]
-                    pick['matchup'] = matchup_cell.get_text(strip=True)
-
-                    # Extract teams if available
-                    team_links = matchup_cell.find_all('a')
-                    if len(team_links) >= 2:
-                        pick['away_team'] = team_links[0].get_text(strip=True)
-                        pick['home_team'] = team_links[1].get_text(strip=True)
-
-                    # Extract expert picks from remaining cells
-                    pick['experts'] = []
-                    for cell in cells[1:]:
-                        expert_pick = cell.get_text(strip=True)
-                        if expert_pick:
-                            pick['experts'].append(expert_pick)
-
-                    if pick.get('matchup'):
-                        processed_picks.append(pick)
-        else:
-            # Alternative: look for individual pick cards/containers
-            pick_containers = soup.find_all(['div', 'article'], class_=re.compile(r'pick|game|matchup', re.I))
-
-            for container in pick_containers:
-                pick = {}
-
-                # Extract matchup info
-                matchup_elem = container.find(['h3', 'h4', 'div'], class_=re.compile(r'matchup|game|title', re.I))
-                if matchup_elem:
-                    pick['matchup'] = matchup_elem.get_text(strip=True)
-
-                # Extract expert name and pick
-                expert_elem = container.find(['span', 'div'], class_=re.compile(r'expert|analyst', re.I))
-                if expert_elem:
-                    pick['expert'] = expert_elem.get_text(strip=True)
-
-                prediction_elem = container.find(['span', 'div'], class_=re.compile(r'pick|prediction', re.I))
-                if prediction_elem:
-                    pick['prediction'] = prediction_elem.get_text(strip=True)
-
-                if pick.get('matchup'):
-                    processed_picks.append(pick)
+            _skip_codes = {'CBS', 'NBC', 'FOX', 'ESPN', 'NFL', 'TNF', 'SNF', 'MNF',
+                           'AM', 'PM', 'ET', 'FINAL', 'BYE'}
+            for row in rows[1:]:
+                cells = row.find_all(['th', 'td'])
+                if len(cells) < 2:
+                    continue
+                matchup = re.sub(r'\s+', ' ', cells[0].get_text(' ', strip=True))
+                if not matchup or matchup.lower().startswith('week'):
+                    continue  # skip the records row / empty rows
+                teams = [t for t in re.findall(r'\b[A-Z]{2,3}\b', matchup) if t not in _skip_codes]
+                picks_by_expert = {}
+                for i, cell in enumerate(cells[1:]):
+                    txt = re.sub(r'\s+', ' ', cell.get_text(' ', strip=True))
+                    if i < len(experts) and txt:
+                        picks_by_expert[experts[i]] = txt
+                processed_picks.append({
+                    "matchup": matchup,
+                    "away_team": teams[0] if len(teams) >= 1 else None,
+                    "home_team": teams[1] if len(teams) >= 2 else None,
+                    "picks": picks_by_expert,
+                })
 
         return create_success_response({
             "picks": processed_picks,
             "total_picks": len(processed_picks),
+            "experts": experts,
             "week": week,
             "source": "CBS Sports Expert Picks"
         })

--- a/nfl_mcp/nfl_tools.py
+++ b/nfl_mcp/nfl_tools.py
@@ -1102,56 +1102,53 @@ async def get_league_leaders(category: str, season: int = 2026, season_type: int
             players_local: list[dict[str, Any]] = []
             cache: dict[str, Any] = {}
 
-            # Collect leader groups (dereference group if needed)
-            leader_groups = cat_obj.get('leaders', []) or []
-
-            async def expand_group(group):
-                # If no inline leaders but has ref/href, dereference
-                if not group.get('leaders'):
-                    for ref_key in ('$ref', 'href'):
-                        if ref_key in group and isinstance(group[ref_key], str):
-                            fetched = await _fetch_json(group[ref_key], client, headers, cache)
-                            if fetched:
-                                return fetched.get('leaders') or fetched.get('items') or []
-                return group.get('leaders') or []
-
-            expanded_lists = [expand_group(grp) for grp in leader_groups]
-            expanded = await asyncio.gather(*expanded_lists) if expanded_lists else []
-
-            # Flatten entries
+            # ESPN returns `leaders` as a FLAT list of leader entries (each with
+            # value + athlete/team refs). A leader entry has no nested `leaders`,
+            # so the old group-expansion returned [] -> 0 players. Use entries
+            # directly; only flatten/deref the rare "group" wrapper.
+            raw = cat_obj.get('leaders', []) or []
             entries: list[dict[str, Any]] = []
-            for lst in expanded:
-                entries.extend(lst)
+            for item in raw:
+                if not isinstance(item, dict):
+                    continue
+                if item.get('athlete') or 'value' in item:
+                    entries.append(item)                       # a leader entry itself
+                elif item.get('leaders'):
+                    entries.extend(item['leaders'])            # nested group
+                elif item.get('$ref') or item.get('href'):
+                    fetched = await _fetch_json(item.get('$ref') or item.get('href'), client, headers, cache)
+                    if fetched:
+                        entries.extend(fetched.get('leaders') or fetched.get('items') or [])
 
-            async def enrich_entry(entry):
-                athlete = entry.get('athlete', {}) or {}
-                team = entry.get('team', {}) or {}
-                # Deref athlete/team if only reference
-                for key_obj, label in ((athlete, 'athlete'), (team, 'team')):
-                    if isinstance(key_obj, dict) and ('$ref' in key_obj or 'href' in key_obj):
-                        ref_url = key_obj.get('$ref') or key_obj.get('href')
-                        data = await _fetch_json(ref_url, client, headers, cache)
+            async def enrich_entry(rank, entry):
+                athlete = dict(entry.get('athlete') or {})
+                team = dict(entry.get('team') or {})
+                for obj in (athlete, team):
+                    if '$ref' in obj or 'href' in obj:
+                        data = await _fetch_json(obj.get('$ref') or obj.get('href'), client, headers, cache)
                         if data:
-                            if label == 'athlete':
-                                athlete.update(data)
-                            else:
-                                team.update(data)
-                players_local.append({
-                    "rank": entry.get('rank'),
+                            obj.update(data)
+                pos = athlete.get('position') or {}
+                return {
+                    "rank": rank,
                     "value": entry.get('value'),
+                    "display_value": entry.get('displayValue'),
                     "athlete_id": athlete.get('id'),
                     "athlete_name": athlete.get('displayName') or athlete.get('shortName'),
+                    "position": pos.get('abbreviation') if isinstance(pos, dict) else None,
                     "team_id": team.get('id'),
                     "team_abbr": team.get('abbreviation'),
-                })
+                }
 
-            tasks = [enrich_entry(e) for e in entries]
-            if tasks:
-                semaphore = asyncio.Semaphore(10)
-                async def sem_task(coro):
-                    async with semaphore:
-                        return await coro
-                await asyncio.gather(*(sem_task(t) for t in tasks))
+            semaphore = asyncio.Semaphore(10)
+
+            async def sem_task(rank, e):
+                async with semaphore:
+                    return await enrich_entry(rank, e)
+
+            players_local = list(await asyncio.gather(
+                *(sem_task(i + 1, e) for i, e in enumerate(entries))
+            ))
             return players_local
 
         if not multi:


### PR DESCRIPTION
The two items explicitly deferred from the 0.7.5 audit remediation — both verified against live data.

## `get_league_leaders` — returned empty even for completed seasons
ESPN's `.../leaders` endpoint returns each category's `leaders` as a **flat list** of leader entries (each carrying an `athlete` `$ref` + `value`). The parser treated every entry as a *group* and called `expand_group`, which returned `[]` (a leader entry has no nested `leaders`), so the flattened result was empty. Now it uses the entries directly, dereferences athlete/team, and assigns ordered ranks.

```
2024 passing -> 1 Joe Burrow (4918, CIN) · 2 Jared Goff (4629, DET) · 3 Baker Mayfield (4500, TB)
2024 rushing -> Saquon Barkley …
```
(The wrapper shape/label/limit bug was already fixed in #144; this is the underlying extraction.)

## `get_cbs_expert_picks` — garbled scraped text
Rewrote the scraper for CBS's `TableExpertPicks` layout:
- expert names cleaned from the header row (was duplicated/whitespace-laden),
- per-game `picks` keyed by expert name,
- `away_team`/`home_team` extracted from the matchup cell,
- whitespace collapsed.

```
experts: [Pete Prisco, Cody Benjamin, Jared Dubin, Ryan Wilson, John Breech, …]
DAL@PHI → {Pete Prisco: "WIN DAL +7", Cody Benjamin: "WIN DAL +7", …}
```
(was `"FINALNBCDAL7-9-120PHI11-624Recap"` blobs).

Full suite: **922 passed, 2 skipped**. Ruff clean.

**This closes out every actionable audit finding.**