### PR TITLE
chore(release): 0.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.6] - 2026-08-07
+
 ### Fixed
 The two deeper audit follow-ups (deferred from the 0.7.5 batches):
 - **`get_league_leaders` now returns actual leaders.** ESPN's `leaders` endpoint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfl_mcp"
-version = "0.7.5"
+version = "0.7.6"
 description = "NFL MCP Server - Fantasy Football Analysis via Model Context Protocol"
 authors = [{name = "gtonic", email = "tom.geiger@alp54.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
Release **0.7.6** — the two deferred audit follow-ups (from #149).

- **`get_league_leaders`** now returns actual leaders (ESPN's flat `leaders` list was mis-treated as groups → empty; now dereferenced with ordered rank).
- **`get_cbs_expert_picks`** rewritten for the `TableExpertPicks` layout (clean experts, per-game picks keyed by expert, away/home teams) instead of garbled concatenated text.

Diff is release-only. Tag `v0.7.6` publishes `ghcr.io/gtonic/nfl_mcp:0.7.6`. This closes out every actionable finding from the multi-agent tool audit.